### PR TITLE
Fix SSL error test and stub external deps

### DIFF
--- a/email_claude_api.py
+++ b/email_claude_api.py
@@ -22,8 +22,9 @@ print(f"Claude API model in use: {CLAUDE_DEFAULT_MODEL}")
 import io
 
 # Configure stdout/stderr for UTF-8 to properly handle emojis in console output
-sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
-sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
+if not os.environ.get("PYTEST_RUNNING"):
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
 
 logging.basicConfig(
     level=logging.INFO,

--- a/email_gui.py
+++ b/email_gui.py
@@ -76,8 +76,9 @@ except ImportError:
 
 # Configure logging
 # Configure stdout/stderr for UTF-8 to properly handle emojis in console output
-sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
-sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
+if not os.environ.get("PYTEST_RUNNING"):
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
 
 logging.basicConfig(
     level=logging.INFO,

--- a/email_main.py
+++ b/email_main.py
@@ -21,7 +21,10 @@ os.environ["STREAMLIT_SERVER_FILE_WATCHER_TYPE"] = "none"
 
 import faulthandler
 
-faulthandler.enable()
+# Avoid enabling faulthandler during tests as it interferes with pytest's
+# output capture. It can be enabled when running as a script if needed.
+if not os.environ.get("PYTEST_RUNNING"):
+    faulthandler.enable()
 
 import os
 import sys
@@ -398,7 +401,6 @@ class GmailChatbotApp:
         """Returns the stored error message from vector search initialization, if any."""
         return self.vector_search_error_message
 
-{{ ... }}
     def _is_simple_inbox_query(self, message_lower: str) -> bool:
         """Checks if a query is a simple request for inbox contents, suitable for a menu."""
         generic_inbox_phrases = [

--- a/ml_classifier/test_ml_classifier.py
+++ b/ml_classifier/test_ml_classifier.py
@@ -13,8 +13,11 @@ ROOT_DIR = Path(__file__).parent
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
-# Import the classifier
-from ml_query_classifier import predict
+# Import the classifier lazily to avoid import errors during test collection
+try:
+    from ml_query_classifier import predict
+except Exception:  # pragma: no cover - if dependencies are missing
+    predict = None
 
 # Test queries
 TEST_QUERIES = [


### PR DESCRIPTION
## Summary
- stub out missing third-party modules so tests can run without network
- guard stdout/stderr manipulations when running under pytest
- update DiskStore to fall back if portalocker is unavailable
- handle optional torch import in email_vector_db
- fix Gmail API SSL error test using context managers
- avoid ImportError in ml_classifier test helper

## Testing
- `pytest tests/test_email_gmail_api.py::TestGmailAPIClientSSLErrors::test_authenticate_ssl_error_on_refresh_then_flow_fails -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv', faiss)*

------
https://chatgpt.com/codex/tasks/task_b_683f0418051c8326a4556be66eb2479e