### PR TITLE
Validate email metadata before vector indexing

### DIFF
--- a/tests/test_enhanced_memory.py
+++ b/tests/test_enhanced_memory.py
@@ -181,6 +181,7 @@ class TestEnhancedMemoryStore(unittest.TestCase):
                 "subject": "Test Email",
                 "sender": "sender@example.com",
                 "recipient": "recipient@example.com",
+                "date": "2024-01-01T00:00:00Z",
                 "client": "Test Client"
             }
         )
@@ -253,6 +254,9 @@ class TestEnhancedMemoryStore(unittest.TestCase):
             meta={
                 "email_id": "school1",
                 "subject": "Excel High School Progress Report",
+                "sender": "teacher@example.com",
+                "recipient": "parent@example.com",
+                "date": "2024-01-02T00:00:00Z",
                 "client": "Excel High School"
             }
         ))


### PR DESCRIPTION
## Summary
- add `_append_email_memory` helper in `EnhancedMemoryStore`
- validate required email fields before pushing to vector DB
- update tests to supply complete metadata

## Testing
- `pytest tests/test_enhanced_memory.py::TestEnhancedMemoryStore::test_email_memory -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'anthropic')*

------
https://chatgpt.com/codex/tasks/task_b_683f11681778832688ba48ead077f46c