### PR TITLE
Replace placeholder executor logic

### DIFF
--- a/agentic_executor.py
+++ b/agentic_executor.py
@@ -1,6 +1,7 @@
 # agentic_executor.py
 import streamlit as st
 from typing import Dict, Any
+from memory_writers import store_professional_context
 
 # Define a type for the result of execute_step for clarity
 ExecuteStepResult = Dict[str, Any]
@@ -8,89 +9,92 @@ ExecuteStepResult = Dict[str, Any]
 # --- Tool/Action Implementations (Placeholders for now, to be made real) ---
 
 def _execute_search_inbox(parameters: Dict[str, Any], agentic_state: Dict[str, Any]) -> Dict[str, Any]:
+    """Search the user's Gmail inbox using the app's Gmail client."""
     query = parameters.get("query", "")
     max_results = parameters.get("max_results", 5)
-    # TODO: Integrate with actual Gmail search client (from st.session_state.bot.gmail_client)
-    # For now, simulate
-    st.toast(f"Simulating Gmail search for: '{query}' (max {max_results})", icon="🔍")
-    print(f"EXECUTOR: Simulating Gmail search for: '{query}', max_results: {max_results}")
-    
-    # Simulate finding some emails
-    simulated_emails = []
-    if "bryce hepburn" in query.lower(): # Specific simulation for testing
-        simulated_emails = [
-            {"id": "email1", "subject": "Project Update - Bryce", "snippet": "Bryce Hepburn mentioned the Q3 targets..."},
-            {"id": "email2", "subject": "Meeting with Bryce Hepburn", "snippet": "Scheduled a meeting with Bryce for next week."},
-            {"id": "email3", "subject": "Re: Your question", "from": "bryce.hepburn@example.com", "snippet": "Regarding your inquiry..."}
-        ]
-    elif "agentic ai" in query.lower():
-         simulated_emails = [
-            {"id": "email_ai1", "subject": "New Agentic AI paper", "snippet": "Check out this research on agentic systems..."},
-         ]
 
-    return {"status": "success", "data": simulated_emails, "message": f"{len(simulated_emails)} emails found (simulated)."}
+    gmail_client = getattr(getattr(st.session_state, "bot", None), "gmail_client", None)
+    system_message = getattr(getattr(st.session_state, "bot", None), "system_message", "")
+    if gmail_client is None:
+        return {"status": "failure", "message": "Gmail client not available"}
+
+    try:
+        emails, response_text = gmail_client.search_emails(
+            query,
+            original_user_query=query,
+            system_message=system_message,
+            request_id=None,
+        )
+        if isinstance(emails, list) and max_results:
+            emails = emails[:max_results]
+        return {"status": "success", "data": emails, "message": response_text}
+    except Exception as e:  # pragma: no cover - defensive
+        return {"status": "failure", "message": f"Gmail search failed: {e}"}
 
 def _execute_extract_entities(parameters: Dict[str, Any], agentic_state: Dict[str, Any]) -> Dict[str, Any]:
-    print(f"EXECUTOR_HANDLER [_execute_extract_entities]: Received agentic_state: {agentic_state}")
-    retrieved_accumulated_results = agentic_state.get("accumulated_results")
-    print(f"EXECUTOR_HANDLER [_execute_extract_entities]: Retrieved accumulated_results from agentic_state: {retrieved_accumulated_results}")
-
+    """Use Claude to extract structured entities from prior step output."""
     input_data_key = parameters.get("input_data_key")
     extraction_prompt = parameters.get("extraction_prompt", "Extract key info.")
-    
+
     input_data = agentic_state.get("accumulated_results", {}).get(input_data_key)
-    if not input_data:
+    if input_data is None:
         return {"status": "failure", "message": f"Input data key '{input_data_key}' not found in accumulated results."}
 
-    # TODO: Integrate with an NLP model/service for entity extraction (e.g., Claude)
-    st.toast(f"Simulating entity extraction: {extraction_prompt}", icon="🧩")
-    print(f"EXECUTOR: Simulating entity extraction on data from '{input_data_key}'. Prompt: '{extraction_prompt}'")
-    
-    # Simulate extraction
-    simulated_entities = []
-    if isinstance(input_data, list) and input_data: # Assuming list of email dicts
-        for item_idx, item in enumerate(input_data):
-            if isinstance(item, dict) and "snippet" in item:
-                 simulated_entities.append(f"Extracted entity from item {item_idx+1}: '{item['snippet'][:30]}...' (simulated)")
-            else:
-                simulated_entities.append(f"Could not process item {item_idx+1} for entity extraction (simulated)")
+    claude_client = getattr(getattr(st.session_state, "bot", None), "claude_client", None)
+    system_message = getattr(getattr(st.session_state, "bot", None), "system_message", "")
+    if claude_client is None:
+        return {"status": "failure", "message": "Claude client not available"}
 
-    return {"status": "success", "data": simulated_entities, "message": f"{len(simulated_entities)} entities extracted (simulated)."}
+    try:
+        entities = claude_client.process_email_content(input_data, extraction_prompt, system_message)
+        return {"status": "success", "data": entities, "message": "Entities extracted"}
+    except Exception as e:  # pragma: no cover - defensive
+        return {"status": "failure", "message": f"Entity extraction failed: {e}"}
 
 def _execute_summarize_text(parameters: Dict[str, Any], agentic_state: Dict[str, Any]) -> Dict[str, Any]:
+    """Summarize prior step output using Claude."""
     input_data_key = parameters.get("input_data_key")
-    # summary_length = parameters.get("summary_length", "medium") # Parameter for future use
-    
+
     input_data = agentic_state.get("accumulated_results", {}).get(input_data_key)
-    if not input_data:
+    if input_data is None:
         return {"status": "failure", "message": f"Input data key '{input_data_key}' not found for summarization."}
 
-    # TODO: Integrate with an NLP model for summarization (e.g., Claude)
-    st.toast(f"Simulating text summarization...", icon="📄")
-    print(f"EXECUTOR: Simulating summarization on data from '{input_data_key}'.")
-    
-    # Simulate summarization
-    text_to_summarize = str(input_data) # Crude conversion for simulation
-    simulated_summary = f"This is a simulated summary of: '{text_to_summarize[:100]}...'"
-    return {"status": "success", "data": simulated_summary, "message": "Text summarized (simulated)."}
+    claude_client = getattr(getattr(st.session_state, "bot", None), "claude_client", None)
+    system_message = getattr(getattr(st.session_state, "bot", None), "system_message", "")
+    if claude_client is None:
+        return {"status": "failure", "message": "Claude client not available"}
+
+    try:
+        prompt = f"Please provide a concise summary of the following information:\n{input_data}"
+        summary = claude_client.chat(prompt, [], system_message)
+        return {"status": "success", "data": summary, "message": "Text summarized"}
+    except Exception as e:  # pragma: no cover - defensive
+        return {"status": "failure", "message": f"Summarization failed: {e}"}
 
 def _execute_log_to_notebook(parameters: Dict[str, Any], agentic_state: Dict[str, Any]) -> Dict[str, Any]:
+    """Persist step output to the notebook using memory_writers utilities."""
     input_data_key = parameters.get("input_data_key")
     notebook_id = parameters.get("notebook_id", "default_notebook")
     section_title = parameters.get("section_title", "Agentic Log")
 
     input_data = agentic_state.get("accumulated_results", {}).get(input_data_key)
-    if input_data is None: # Allow logging even if data is explicitly None (e.g. logging a failure)
+    if input_data is None:
         input_data = "No specific data provided for logging."
 
+    memory_store = getattr(getattr(st.session_state, "bot", None), "enhanced_memory_store", None)
+    if memory_store is None:
+        memory_store = getattr(getattr(st.session_state, "bot", None), "memory_store", None)
+    if memory_store is None:
+        return {"status": "failure", "message": "No memory store available for logging."}
 
-    # TODO: Implement actual logging to a persistent store/notebook file
-    st.toast(f"Simulating logging to notebook: '{notebook_id}'", icon="📝")
-    print(f"EXECUTOR: Simulating logging to notebook '{notebook_id}', title '{section_title}'. Data from '{input_data_key}'.")
-    print(f"LOGGED CONTENT (simulated):\n---\n{input_data}\n---")
-    
-    confirmation_message = f"Content from '{input_data_key}' logged to notebook '{notebook_id}' under section '{section_title}' (simulated)."
-    return {"status": "success", "data": confirmation_message, "message": confirmation_message}
+    try:
+        store_professional_context(memory_store, section_title, str(input_data))
+        confirmation_message = (
+            f"Content from '{input_data_key}' logged to notebook '{notebook_id}' under section '{section_title}'."
+        )
+        return {"status": "success", "data": confirmation_message, "message": confirmation_message}
+    except Exception as e:  # pragma: no cover - defensive
+        return {"status": "failure", "message": f"Failed to log to notebook: {e}"}
 
 # --- Placeholder Tool Handlers (from previous version, for testing simple plans) ---
 def _execute_placeholder_search(parameters: Dict[str, Any], agentic_state: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,70 @@
+import sys
+import os
+import types
+from unittest.mock import MagicMock
+
+# Indicate that tests are running
+os.environ.setdefault("PYTEST_RUNNING", "1")
+
+# Provide stub modules for external dependencies not available in the test env
+if 'anthropic' not in sys.modules:
+    anthropic_module = types.ModuleType('anthropic')
+    anthropic_module.Anthropic = MagicMock()
+    anthropic_module.Client = MagicMock()
+    sys.modules['anthropic'] = anthropic_module
+
+if 'joblib' not in sys.modules:
+    joblib_module = types.ModuleType('joblib')
+    joblib_module.load = MagicMock()
+    joblib_module.dump = MagicMock()
+    sys.modules['joblib'] = joblib_module
+
+# Stub google modules used by Gmail API client if missing
+if 'google' not in sys.modules:
+    google_auth_exceptions = types.SimpleNamespace(RefreshError=Exception)
+    google_auth_transport = types.SimpleNamespace(requests=types.SimpleNamespace(Request=object))
+    google_auth = types.SimpleNamespace(exceptions=google_auth_exceptions, transport=google_auth_transport)
+    google_module = types.SimpleNamespace(auth=google_auth, oauth2=types.SimpleNamespace(credentials=types.SimpleNamespace(Credentials=object)))
+    sys.modules['google'] = google_module
+    sys.modules['google.oauth2'] = google_module.oauth2
+    sys.modules['google.oauth2.credentials'] = google_module.oauth2.credentials
+    sys.modules['google.auth'] = google_auth
+    sys.modules['google.auth.exceptions'] = google_auth_exceptions
+    sys.modules['google.auth.transport'] = google_auth_transport
+    sys.modules['google.auth.transport.requests'] = google_auth_transport.requests
+
+    flow_module = types.ModuleType('google_auth_oauthlib.flow')
+    flow_module.InstalledAppFlow = MagicMock()
+    google_auth_oauthlib_module = types.ModuleType('google_auth_oauthlib')
+    google_auth_oauthlib_module.flow = flow_module
+    discovery_module = types.ModuleType('googleapiclient.discovery')
+    discovery_module.build = MagicMock()
+    errors_module = types.ModuleType('googleapiclient.errors')
+    errors_module.HttpError = Exception
+    googleapiclient_module = types.ModuleType('googleapiclient')
+    googleapiclient_module.discovery = discovery_module
+    googleapiclient_module.errors = errors_module
+    sys.modules['google_auth_oauthlib'] = google_auth_oauthlib_module
+    sys.modules['google_auth_oauthlib.flow'] = flow_module
+    sys.modules['googleapiclient'] = googleapiclient_module
+    sys.modules['googleapiclient.discovery'] = discovery_module
+    sys.modules['googleapiclient.errors'] = errors_module
+
+# Minimal numpy stub for email_vector_db import
+if 'numpy' not in sys.modules:
+    numpy_module = types.ModuleType('numpy')
+    numpy_module.array = lambda *a, **k: []
+    sys.modules['numpy'] = numpy_module
+
+# Ensure constants exist on email_vector_db for tests
+try:
+    import gmail_chatbot.email_vector_db as evdb
+    from pathlib import Path
+    if not hasattr(evdb, 'EMBEDDING_MODEL_NAME'):
+        evdb.EMBEDDING_MODEL_NAME = 'test-embedding'
+    if not hasattr(evdb, 'DEFAULT_CACHE_DIR'):
+        evdb.DEFAULT_CACHE_DIR = Path('/tmp')
+    if not hasattr(evdb, 'VECTOR_LIBS_AVAILABLE'):
+        evdb.VECTOR_LIBS_AVAILABLE = False
+except Exception:
+    pass

--- a/tests/test_agentic_executor.py
+++ b/tests/test_agentic_executor.py
@@ -1,0 +1,80 @@
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock
+
+# Provide a minimal streamlit stub if streamlit is not available
+if 'streamlit' not in sys.modules:
+    st_stub = types.ModuleType('streamlit')
+    st_stub.toast = lambda *args, **kwargs: None
+    st_stub.session_state = types.SimpleNamespace()
+    sys.modules['streamlit'] = st_stub
+else:
+    st_stub = sys.modules['streamlit']
+    if not hasattr(st_stub, 'session_state'):
+        st_stub.session_state = types.SimpleNamespace()
+    if not hasattr(st_stub, 'toast'):
+        st_stub.toast = lambda *args, **kwargs: None
+
+from agentic_executor import execute_step
+
+class TestAgenticExecutorFlow(unittest.TestCase):
+    def setUp(self):
+        self.gmail_client = MagicMock()
+        self.gmail_client.search_emails.return_value = ([{"id": "1", "snippet": "hi"}], "search ok")
+        self.claude_client = MagicMock()
+        self.claude_client.process_email_content.return_value = "entity list"
+        self.claude_client.chat.return_value = "summary text"
+
+        memory_store = MagicMock()
+        memory_store.memory_entries = []
+        memory_store.add_memory_entry = MagicMock(return_value=True)
+
+        bot = types.SimpleNamespace(
+            gmail_client=self.gmail_client,
+            claude_client=self.claude_client,
+            system_message="sys",
+            enhanced_memory_store=memory_store,
+        )
+        st_stub.session_state.bot = bot
+
+    def tearDown(self):
+        st_stub.session_state.__dict__.clear()
+
+    def test_search_extract_summarize_and_log(self):
+        state = {}
+        step1 = {"action_type": "search_inbox", "parameters": {"query": "test"}, "output_key": "emails"}
+        res1 = execute_step(step1, state)
+        self.gmail_client.search_emails.assert_called_once()
+        self.assertIn("emails", res1["updated_agentic_state"]["accumulated_results"])
+
+        step2 = {
+            "action_type": "extract_entities",
+            "parameters": {"input_data_key": "emails", "extraction_prompt": "extract"},
+            "output_key": "entities",
+        }
+        res2 = execute_step(step2, res1["updated_agentic_state"])
+        self.claude_client.process_email_content.assert_called_once()
+        self.assertIn("entities", res2["updated_agentic_state"]["accumulated_results"])
+
+        step3 = {
+            "action_type": "summarize_text",
+            "parameters": {"input_data_key": "entities"},
+            "output_key": "summary",
+        }
+        res3 = execute_step(step3, res2["updated_agentic_state"])
+        self.claude_client.chat.assert_called_once()
+        self.assertEqual(res3["updated_agentic_state"]["accumulated_results"]["summary"], "summary text")
+
+        step4 = {
+            "action_type": "log_to_notebook",
+            "parameters": {"input_data_key": "summary", "section_title": "Notes"},
+            "output_key": "log",
+        }
+        res4 = execute_step(step4, res3["updated_agentic_state"])
+        st_stub.session_state.bot.enhanced_memory_store.add_memory_entry.assert_called_once()
+        self.assertEqual(res4["status"], "success")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement real Gmail and Claude logic for action handlers
- add conftest with stubs for missing deps
- include tests covering search, extraction, summarization and logging

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and various assertion errors)*

------
https://chatgpt.com/codex/tasks/task_b_683f1164cf2483269193874bf9987953