### PR TITLE
Improve Streamlit chat flow

### DIFF
--- a/chat_app_st.py
+++ b/chat_app_st.py
@@ -5,6 +5,7 @@ import traceback
 
 import io
 import time
+import json
 from pathlib import Path
 import dotenv
 from agentic_planner import generate_plan
@@ -288,89 +289,94 @@ if prompt := st.chat_input("Ask me about your inbox:"):
         st.error("Chatbot is not initialized. Cannot process messages.")
         st.stop() # Stop current script run
 
-    # --- Agentic Execution Loop ---
-    if st.session_state.get("agentic_mode_enabled") and st.session_state.get("agentic_plan"):
-        plan = st.session_state.agentic_plan
-        agentic_state = st.session_state.agentic_state # This is a dict
-        
-        current_step_idx = agentic_state.get("current_step_index", 0)
-        executed_call_count = agentic_state.get("executed_call_count", 0)
-        step_limit = st.session_state.get("agentic_step_limit", 10)
 
-        st.info(f"🤖 Agentic Mode: Executing Plan ({current_step_idx}/{len(plan)} steps completed, {executed_call_count}/{step_limit} calls made)")
-        if len(plan) > 0:
-            st.progress(current_step_idx / len(plan))
-
-        # Check if call limit reached
-        if executed_call_count >= step_limit:
-            if not agentic_state.get("limit_reached_flag", False): # Prevent multiple summaries if stuck
-                summarize_and_log_agentic_results(agentic_state, plan_completed=False, limit_reached=True)
-                st.warning(f"Agentic execution stopped: Call limit of {step_limit} reached. Partial results (if any) logged.")
-                agentic_state["limit_reached_flag"] = True
-                st.session_state.agentic_plan = None # Stop further execution
+    # Determine how to handle the prompt based on agentic mode
+    if st.session_state.get("agentic_mode_enabled"):
+        if not st.session_state.get("agentic_plan"):
+            with st.spinner("Bot is thinking..."):
+                plan = generate_plan(prompt, st.session_state)
+            if plan:
+                st.session_state.agentic_plan = plan
                 st.session_state.agentic_state = default_agentic_state_values.copy()
-                st.button("Acknowledge & Clear Plan", on_click=lambda: setattr(st.session_state, 'agentic_plan', None) or st.rerun())
-            # No 'Next Step' button if limit is reached and plan is cleared.
+                plan_str = json.dumps(plan, indent=2)
+                with st.chat_message("assistant"):
+                    st.markdown("**Generated Plan:**")
+                    st.json(plan)
+                st.session_state.bot.chat_history.append({"role": "assistant", "content": f"Generated Plan:\n{plan_str}"})
+        if st.session_state.get("agentic_plan"):
+            plan = st.session_state.agentic_plan
+            agentic_state = st.session_state.agentic_state  # This is a dict
 
-        # Check if plan is still active (not cleared by limit or completion)
-        elif st.session_state.get("agentic_plan") and current_step_idx < len(plan):
-            step_details = plan[current_step_idx]
-            st.markdown(f"**Current Task:** {step_details.get('description', 'No description')}")
+            current_step_idx = agentic_state.get("current_step_index", 0)
+            executed_call_count = agentic_state.get("executed_call_count", 0)
+            step_limit = st.session_state.get("agentic_step_limit", 10)
 
-            # Placeholder for "Pause/Resume/Abort" later
-            # For now, execution proceeds with "Next Step" button
+            st.info(f"🤖 Agentic Mode: Executing Plan ({current_step_idx}/{len(plan)} steps completed, {executed_call_count}/{step_limit} calls made)")
+            if len(plan) > 0:
+                st.progress(current_step_idx / len(plan))
 
-            if st.button(f"Execute Step {current_step_idx + 1}: {step_details.get('step_id', 'Unnamed')}", key=f"exec_step_{current_step_idx}"):
-                with st.spinner(f"Executing: {step_details.get('description', 'Working...')}"):
-                    try:
-                        print(f"CHAT_APP_ST [DEBUG]: st.session_state.agentic_state BEFORE execute_step call for step {current_step_idx + 1}: {st.session_state.agentic_state}")
-                        execution_result = execute_step(step_details, st.session_state.agentic_state) # Pass the session state directly
-                        st.toast(f"DEBUG: execute_step returned: {execution_result.get('status')}", icon="📋") # DEBUG
-                        
-                        # Update agentic_state with the returned state from execute_step
-                        st.session_state.agentic_state = execution_result.get("updated_agentic_state", agentic_state)
-                        st.session_state.agentic_state["executed_call_count"] = executed_call_count + 1
+            # Check if call limit reached
+            if executed_call_count >= step_limit:
+                if not agentic_state.get("limit_reached_flag", False):  # Prevent multiple summaries if stuck
+                    summarize_and_log_agentic_results(agentic_state, plan_completed=False, limit_reached=True)
+                    st.warning(f"Agentic execution stopped: Call limit of {step_limit} reached. Partial results (if any) logged.")
+                    agentic_state["limit_reached_flag"] = True
+                    st.session_state.agentic_plan = None  # Stop further execution
+                    st.session_state.agentic_state = default_agentic_state_values.copy()
+                    st.button("Acknowledge & Clear Plan", on_click=lambda: setattr(st.session_state, 'agentic_plan', None) or st.rerun())
+            # Check if plan is still active (not cleared by limit or completion)
+            elif st.session_state.get("agentic_plan") and current_step_idx < len(plan):
+                step_details = plan[current_step_idx]
+                st.markdown(f"**Current Task:** {step_details.get('description', 'No description')}")
 
-                        if execution_result.get("status") == "failure":
-                            error_msg = f"Step {current_step_idx + 1} ('{step_details.get('step_id', 'Unnamed')}') failed: {execution_result.get('message', 'Unknown error')}"
-                            st.error(error_msg)
-                            if "error_messages" not in st.session_state.agentic_state:
-                                st.session_state.agentic_state["error_messages"] = []
-                            st.session_state.agentic_state["error_messages"].append(error_msg)
-                            summarize_and_log_agentic_results(st.session_state.agentic_state, plan_completed=False)
-                            st.session_state.agentic_plan = None # Stop plan
+                if st.button(f"Execute Step {current_step_idx + 1}: {step_details.get('step_id', 'Unnamed')}", key=f"exec_step_{current_step_idx}"):
+                    with st.spinner(f"Executing: {step_details.get('description', 'Working...')}"):
+                        try:
+                            print(f"CHAT_APP_ST [DEBUG]: st.session_state.agentic_state BEFORE execute_step call for step {current_step_idx + 1}: {st.session_state.agentic_state}")
+                            execution_result = execute_step(step_details, st.session_state.agentic_state)
+                            st.toast(f"DEBUG: execute_step returned: {execution_result.get('status')}", icon="📋")
+
+                            st.session_state.agentic_state = execution_result.get("updated_agentic_state", agentic_state)
+                            st.session_state.agentic_state["executed_call_count"] = executed_call_count + 1
+
+                            if execution_result.get("status") == "failure":
+                                error_msg = f"Step {current_step_idx + 1} ('{step_details.get('step_id', 'Unnamed')}') failed: {execution_result.get('message', 'Unknown error')}"
+                                st.error(error_msg)
+                                if "error_messages" not in st.session_state.agentic_state:
+                                    st.session_state.agentic_state["error_messages"] = []
+                                st.session_state.agentic_state["error_messages"].append(error_msg)
+                                summarize_and_log_agentic_results(st.session_state.agentic_state, plan_completed=False)
+                                st.session_state.agentic_plan = None
+                                st.session_state.agentic_state = default_agentic_state_values.copy()
+                                st.rerun()
+                            elif execution_result.get("requires_user_input", False):
+                                st.info(f"Step {current_step_idx + 1} requires user input: {execution_result.get('message', '')}")
+                                st.rerun()
+                            else:
+                                st.toast(f"DEBUG: Step {current_step_idx + 1} success path reached.", icon="✅")
+                                st.session_state.agentic_state["current_step_index"] = current_step_idx + 1
+                                st.success(f"Step {current_step_idx + 1} completed. {execution_result.get('message', '')}")
+                                st.rerun()
+                        except Exception as e:
+                            st.exception(e)
+                            st.error(f"An unexpected error occurred during step execution: {e}")
+                            st.session_state.agentic_plan = None
                             st.session_state.agentic_state = default_agentic_state_values.copy()
                             st.rerun()
-                        elif execution_result.get("requires_user_input", False):
-                            st.info(f"Step {current_step_idx + 1} requires user input: {execution_result.get('message', '')}")
-                            # UI for user input would go here. For now, just pauses.
-                            st.rerun() # Rerun to show info and wait for next interaction
-                        else: # Success
-                            st.toast(f"DEBUG: Step {current_step_idx + 1} success path reached.", icon="✅") # DEBUG
-                            st.session_state.agentic_state["current_step_index"] = current_step_idx + 1
-                            st.success(f"Step {current_step_idx + 1} completed. {execution_result.get('message', '')}")
-                            st.rerun() # Rerun to process next step or finalize
-                    except Exception as e:
-                        st.exception(e)
-                        st.error(f"An unexpected error occurred during step execution: {e}")
-                        # Clear plan to stop further execution on error
-                        st.session_state.agentic_plan = None 
-                        st.session_state.agentic_state = default_agentic_state_values.copy()
-                        st.rerun() # Rerun to show the error and reflect cleared plan
-            # If button not clicked, Streamlit script just ends, preserving state for next interaction.
-        
-        # Check if plan completed (and not already handled by limit/error)
-        elif st.session_state.get("agentic_plan") and current_step_idx >= len(plan):
-            if not agentic_state.get("completion_logged_flag", False): # Prevent multiple summaries
-                summarize_and_log_agentic_results(agentic_state, plan_completed=True)
-                st.success("🎉 Agentic plan fully completed!")
-                agentic_state["completion_logged_flag"] = True # Mark as logged
-                st.session_state.agentic_plan = None # Clear the completed plan
-                st.session_state.agentic_state = default_agentic_state_values.copy() # Reset state
-                st.balloons()
-                st.button("Acknowledge & Clear", on_click=lambda: setattr(st.session_state, 'agentic_plan', None) or st.rerun())
-    # --- End Agentic Execution Loop ---
-
+            elif st.session_state.get("agentic_plan") and current_step_idx >= len(plan):
+                if not agentic_state.get("completion_logged_flag", False):
+                    summarize_and_log_agentic_results(agentic_state, plan_completed=True)
+                    st.success("🎉 Agentic plan fully completed!")
+                    agentic_state["completion_logged_flag"] = True
+                    st.session_state.agentic_plan = None
+                    st.session_state.agentic_state = default_agentic_state_values.copy()
+                    st.balloons()
+                    st.button("Acknowledge & Clear", on_click=lambda: setattr(st.session_state, 'agentic_plan', None) or st.rerun())
+    else:
+        with st.spinner("Bot is thinking..."):
+            assistant_reply = st.session_state.bot.process_message(prompt)
+        with st.chat_message("assistant"):
+            st.markdown(assistant_reply)
 
 st.sidebar.title("Controls")
 if "batch_mode" not in st.session_state:


### PR DESCRIPTION
## Summary
- add json import
- support plan generation when agentic mode is enabled
- show plan to the user and execute step-by-step
- call `process_message` directly in standard mode

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'anthropic')*

------
https://chatgpt.com/codex/tasks/task_b_683f132b17f48326b6582a343a11e2a4