### PR TITLE
Implement agentic plan execution helper

### DIFF
--- a/chat_app_st.py
+++ b/chat_app_st.py
@@ -9,7 +9,7 @@ import json
 from pathlib import Path
 import dotenv
 from agentic_planner import generate_plan
-from agentic_executor import execute_step, summarize_and_log_agentic_results # Added for agentic execution
+from agentic_executor import execute_step, summarize_and_log_agentic_results  # Added for agentic execution
 
 # --- Global Exception Hook for Debugging ---
 def log_exception_to_file(exc_type, exc_value, exc_traceback):
@@ -83,6 +83,82 @@ if st.session_state.agentic_mode_enabled:
         help="Maximum number of API/tool calls the agent can make autonomously in one go."
     )
 # --- End Agentic Mode Initialization & Controls ---
+
+
+def run_agentic_plan() -> None:
+    """Execute the current agentic plan sequentially with progress feedback."""
+    plan = st.session_state.get("agentic_plan")
+    if not plan:
+        return
+
+    agentic_state = st.session_state.get("agentic_state", default_agentic_state_values.copy())
+    step_limit = st.session_state.get("agentic_step_limit", 10)
+
+    progress_bar = st.progress(
+        agentic_state.get("current_step_index", 0) / max(len(plan), 1)
+    )
+
+    while (
+        agentic_state.get("current_step_index", 0) < len(plan)
+        and agentic_state.get("executed_call_count", 0) < step_limit
+    ):
+        idx = agentic_state.get("current_step_index", 0)
+        step_details = plan[idx]
+        with st.spinner(f"Executing: {step_details.get('description', 'Working...')}"):
+            try:
+                execution_result = execute_step(step_details, agentic_state)
+            except Exception as e:  # pragma: no cover - defensive
+                st.exception(e)
+                st.error(f"An unexpected error occurred during step execution: {e}")
+                st.session_state.agentic_plan = None
+                st.session_state.agentic_state = default_agentic_state_values.copy()
+                return
+
+        agentic_state = execution_result.get("updated_agentic_state", agentic_state)
+        agentic_state["executed_call_count"] = agentic_state.get("executed_call_count", 0) + 1
+
+        if execution_result.get("status") == "failure":
+            error_msg = (
+                f"Step {idx + 1} ('{step_details.get('step_id', 'Unnamed')}') failed:"
+                f" {execution_result.get('message', 'Unknown error')}"
+            )
+            st.error(error_msg)
+            agentic_state.setdefault("error_messages", []).append(error_msg)
+            summarize_and_log_agentic_results(agentic_state, plan_completed=False)
+            st.session_state.agentic_plan = None
+            st.session_state.agentic_state = default_agentic_state_values.copy()
+            return
+
+        if execution_result.get("requires_user_input", False):
+            st.info(
+                f"Step {idx + 1} requires user input: {execution_result.get('message', '')}"
+            )
+            st.session_state.agentic_state = agentic_state
+            progress_bar.progress((idx + 1) / len(plan))
+            return
+
+        agentic_state["current_step_index"] = idx + 1
+        st.session_state.agentic_state = agentic_state
+        progress_bar.progress(agentic_state["current_step_index"] / len(plan))
+
+    if agentic_state.get("current_step_index", 0) >= len(plan):
+        summarize_and_log_agentic_results(agentic_state, plan_completed=True)
+        st.success("🎉 Agentic plan fully completed!")
+        st.session_state.agentic_plan = None
+        st.session_state.agentic_state = default_agentic_state_values.copy()
+        st.balloons()
+    elif agentic_state.get("executed_call_count", 0) >= step_limit:
+        if not agentic_state.get("limit_reached_flag", False):
+            summarize_and_log_agentic_results(
+                agentic_state, plan_completed=False, limit_reached=True
+            )
+            agentic_state["limit_reached_flag"] = True
+        st.warning(
+            f"Agentic execution stopped: Call limit of {step_limit} reached. Partial results (if any) logged."
+        )
+        st.session_state.agentic_plan = None
+        st.session_state.agentic_state = default_agentic_state_values.copy()
+
 
 # Initialize chat history
 
@@ -311,72 +387,15 @@ if prompt := st.chat_input("Ask me about your inbox:"):
             executed_call_count = agentic_state.get("executed_call_count", 0)
             step_limit = st.session_state.get("agentic_step_limit", 10)
 
-            st.info(f"🤖 Agentic Mode: Executing Plan ({current_step_idx}/{len(plan)} steps completed, {executed_call_count}/{step_limit} calls made)")
-            if len(plan) > 0:
-                st.progress(current_step_idx / len(plan))
-
-            # Check if call limit reached
-            if executed_call_count >= step_limit:
-                if not agentic_state.get("limit_reached_flag", False):  # Prevent multiple summaries if stuck
-                    summarize_and_log_agentic_results(agentic_state, plan_completed=False, limit_reached=True)
-                    st.warning(f"Agentic execution stopped: Call limit of {step_limit} reached. Partial results (if any) logged.")
-                    agentic_state["limit_reached_flag"] = True
-                    st.session_state.agentic_plan = None  # Stop further execution
-                    st.session_state.agentic_state = default_agentic_state_values.copy()
-                    st.button("Acknowledge & Clear Plan", on_click=lambda: setattr(st.session_state, 'agentic_plan', None) or st.rerun())
-            # Check if plan is still active (not cleared by limit or completion)
-            elif st.session_state.get("agentic_plan") and current_step_idx < len(plan):
-                step_details = plan[current_step_idx]
-                st.markdown(f"**Current Task:** {step_details.get('description', 'No description')}")
-
-                if st.button(f"Execute Step {current_step_idx + 1}: {step_details.get('step_id', 'Unnamed')}", key=f"exec_step_{current_step_idx}"):
-                    with st.spinner(f"Executing: {step_details.get('description', 'Working...')}"):
-                        try:
-                            print(f"CHAT_APP_ST [DEBUG]: st.session_state.agentic_state BEFORE execute_step call for step {current_step_idx + 1}: {st.session_state.agentic_state}")
-                            execution_result = execute_step(step_details, st.session_state.agentic_state)
-                            st.toast(f"DEBUG: execute_step returned: {execution_result.get('status')}", icon="📋")
-
-                            st.session_state.agentic_state = execution_result.get("updated_agentic_state", agentic_state)
-                            st.session_state.agentic_state["executed_call_count"] = executed_call_count + 1
-
-                            if execution_result.get("status") == "failure":
-                                error_msg = f"Step {current_step_idx + 1} ('{step_details.get('step_id', 'Unnamed')}') failed: {execution_result.get('message', 'Unknown error')}"
-                                st.error(error_msg)
-                                if "error_messages" not in st.session_state.agentic_state:
-                                    st.session_state.agentic_state["error_messages"] = []
-                                st.session_state.agentic_state["error_messages"].append(error_msg)
-                                summarize_and_log_agentic_results(st.session_state.agentic_state, plan_completed=False)
-                                st.session_state.agentic_plan = None
-                                st.session_state.agentic_state = default_agentic_state_values.copy()
-                                st.rerun()
-                            elif execution_result.get("requires_user_input", False):
-                                st.info(f"Step {current_step_idx + 1} requires user input: {execution_result.get('message', '')}")
-                                st.rerun()
-                            else:
-                                st.toast(f"DEBUG: Step {current_step_idx + 1} success path reached.", icon="✅")
-                                st.session_state.agentic_state["current_step_index"] = current_step_idx + 1
-                                st.success(f"Step {current_step_idx + 1} completed. {execution_result.get('message', '')}")
-                                st.rerun()
-                        except Exception as e:
-                            st.exception(e)
-                            st.error(f"An unexpected error occurred during step execution: {e}")
-                            st.session_state.agentic_plan = None
-                            st.session_state.agentic_state = default_agentic_state_values.copy()
-                            st.rerun()
-            elif st.session_state.get("agentic_plan") and current_step_idx >= len(plan):
-                if not agentic_state.get("completion_logged_flag", False):
-                    summarize_and_log_agentic_results(agentic_state, plan_completed=True)
-                    st.success("🎉 Agentic plan fully completed!")
-                    agentic_state["completion_logged_flag"] = True
-                    st.session_state.agentic_plan = None
-                    st.session_state.agentic_state = default_agentic_state_values.copy()
-                    st.balloons()
-                    st.button("Acknowledge & Clear", on_click=lambda: setattr(st.session_state, 'agentic_plan', None) or st.rerun())
-    else:
-        with st.spinner("Bot is thinking..."):
-            assistant_reply = st.session_state.bot.process_message(prompt)
-        with st.chat_message("assistant"):
-            st.markdown(assistant_reply)
+            st.info(
+                f"🤖 Agentic Mode: Executing Plan ({current_step_idx}/{len(plan)} steps completed, {executed_call_count}/{step_limit} calls made)"
+            )
+            run_agentic_plan()
+        else:
+            with st.spinner("Bot is thinking..."):
+                assistant_reply = st.session_state.bot.process_message(prompt)
+            with st.chat_message("assistant"):
+                st.markdown(assistant_reply)
 
 st.sidebar.title("Controls")
 if "batch_mode" not in st.session_state:

--- a/tests/test_agentic_executor.py
+++ b/tests/test_agentic_executor.py
@@ -1,6 +1,7 @@
 import sys
 import types
 import unittest
+import contextlib
 from unittest.mock import MagicMock
 
 # Provide a minimal streamlit stub if streamlit is not available
@@ -8,6 +9,31 @@ if 'streamlit' not in sys.modules:
     st_stub = types.ModuleType('streamlit')
     st_stub.toast = lambda *args, **kwargs: None
     st_stub.session_state = types.SimpleNamespace()
+    # Minimal UI stubs
+    st_stub.set_page_config = lambda *a, **k: None
+    st_stub.title = lambda *a, **k: None
+    st_stub.progress = lambda *a, **k: types.SimpleNamespace(progress=lambda *a2, **k2: None)
+    st_stub.info = lambda *a, **k: None
+    st_stub.error = lambda *a, **k: None
+    st_stub.success = lambda *a, **k: None
+    st_stub.warning = lambda *a, **k: None
+    st_stub.balloons = lambda *a, **k: None
+    @contextlib.contextmanager
+    def spinner(*args, **kwargs):
+        yield
+    st_stub.spinner = spinner
+    st_stub.sidebar = types.SimpleNamespace(
+        subheader=lambda *a, **k: None,
+        success=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        info=lambda *a, **k: None,
+        write=lambda *a, **k: None,
+        markdown=lambda *a, **k: None,
+        expander=lambda *a, **k: contextlib.nullcontext(),
+    )
+    st_stub.json = lambda *a, **k: None
+    st_stub.chat_message = contextlib.nullcontext
+    st_stub.chat_input = lambda *a, **k: None
     sys.modules['streamlit'] = st_stub
 else:
     st_stub = sys.modules['streamlit']
@@ -15,6 +41,33 @@ else:
         st_stub.session_state = types.SimpleNamespace()
     if not hasattr(st_stub, 'toast'):
         st_stub.toast = lambda *args, **kwargs: None
+    if not hasattr(st_stub, 'progress'):
+        st_stub.progress = lambda *a, **k: types.SimpleNamespace(progress=lambda *a2, **k2: None)
+    if not hasattr(st_stub, 'spinner'):
+        @contextlib.contextmanager
+        def spinner(*args, **kwargs):
+            yield
+        st_stub.spinner = spinner
+    if not hasattr(st_stub, 'info'):
+        st_stub.info = lambda *a, **k: None
+    if not hasattr(st_stub, 'error'):
+        st_stub.error = lambda *a, **k: None
+    if not hasattr(st_stub, 'success'):
+        st_stub.success = lambda *a, **k: None
+    if not hasattr(st_stub, 'warning'):
+        st_stub.warning = lambda *a, **k: None
+    if not hasattr(st_stub, 'balloons'):
+        st_stub.balloons = lambda *a, **k: None
+    if not hasattr(st_stub, 'sidebar'):
+        st_stub.sidebar = types.SimpleNamespace(
+            subheader=lambda *a, **k: None,
+            success=lambda *a, **k: None,
+            warning=lambda *a, **k: None,
+            info=lambda *a, **k: None,
+            write=lambda *a, **k: None,
+            markdown=lambda *a, **k: None,
+            expander=lambda *a, **k: contextlib.nullcontext(),
+        )
 
 from agentic_executor import execute_step
 
@@ -74,6 +127,35 @@ class TestAgenticExecutorFlow(unittest.TestCase):
         res4 = execute_step(step4, res3["updated_agentic_state"])
         st_stub.session_state.bot.enhanced_memory_store.add_memory_entry.assert_called_once()
         self.assertEqual(res4["status"], "success")
+
+    def test_sequential_plan_execution(self):
+        plan = [
+            {
+                "step_id": "test_search_step",
+                "description": "Step 1",
+                "action_type": "placeholder_search_tool",
+                "parameters": {"query": "agentic"},
+                "output_key": "search_results",
+            },
+            {
+                "step_id": "test_summarize_step",
+                "description": "Step 2",
+                "action_type": "placeholder_summarize_tool",
+                "parameters": {"input_data_key": "search_results"},
+                "output_key": "summary",
+            },
+        ]
+
+        state: dict = {}
+        for step in plan:
+            res = execute_step(step, state)
+            state = res["updated_agentic_state"]
+
+        self.assertIn("summary", state.get("accumulated_results", {}))
+        self.assertEqual(
+            state["accumulated_results"]["summary"],
+            "Simulated summary of 1 documents.",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `run_agentic_plan` helper to automate plan execution
- use it instead of manual button workflow in the Streamlit app
- extend Streamlit stubs in tests and add sequential execution test

## Testing
- `PYTHONPATH=. pytest tests/test_agentic_executor.py -q`

------
https://chatgpt.com/codex/tasks/task_b_683f15331d8c8326af3381eb974c419e