### PR TITLE
Add step limit continue/stop UI with tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Created unit tests for notebook search guard-rail behavior
 - Added robust chat initialization guard-rail to Streamlit app to prevent premature user interaction
 - Implemented detailed step-by-step initialization diagnostics in chat_app_st.py to provide clear error information
+- Added Continue/Stop prompt when autonomous step limit is reached
 
 ### Changed
 

--- a/agentic_executor.py
+++ b/agentic_executor.py
@@ -1,6 +1,6 @@
 # agentic_executor.py
 import streamlit as st
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from memory_writers import store_professional_context
 
 # Define a type for the result of execute_step for clarity
@@ -231,3 +231,25 @@ def summarize_and_log_agentic_results(agentic_state: Dict[str, Any], plan_comple
     print(f"DEBUG: Summarize and Log - Final State: {agentic_state}")
     # The actual "logging to notebook" is now a plan step ("log_to_notebook")
     # This function primarily serves to update the UI with the final status.
+
+
+def handle_step_limit_reached(agentic_state: Dict[str, Any], step_limit: int) -> Optional[str]:
+    """Prompt user when the autonomous call limit is reached.
+
+    Returns "continue" if the user chooses to keep going, "stop" if they opt to
+    halt execution, or ``None`` if no choice was made."""
+    st.warning(
+        f"Agentic execution paused: Call limit of {step_limit} reached."
+    )
+    continue_clicked = st.button("Continue", key="agentic_continue_btn")
+    stop_clicked = st.button("Stop", key="agentic_stop_btn")
+
+    if continue_clicked:
+        agentic_state["executed_call_count"] = 0
+        return "continue"
+    if stop_clicked:
+        summarize_and_log_agentic_results(
+            agentic_state, plan_completed=False, limit_reached=True
+        )
+        return "stop"
+    return None


### PR DESCRIPTION
## Summary
- let users continue or stop when the autonomous call limit is hit
- reset call counter if continuing
- summarise and clear plan when stopping
- cover new helper logic with unit tests

## Testing
- `pytest -q` *(fails: Multiple existing tests fail)*
- `python - <<'PY'
import sys, types, pytest
if 'streamlit' not in sys.modules:
    st = types.ModuleType('streamlit'); st.toast=lambda *a, **k: None; st.session_state=types.SimpleNamespace(); sys.modules['streamlit']=st
pytest.main(['tests/test_agentic_executor.py::TestHandleStepLimitReached::test_continue_choice_resets_count', 'tests/test_agentic_executor.py::TestHandleStepLimitReached::test_stop_choice_triggers_summary', '-q'])
PY`


------
https://chatgpt.com/codex/tasks/task_b_683f15354b9c83268343f10ee2e4e24a