### PR TITLE
Handle Gmail API errors

### DIFF
--- a/chat_app_st.py
+++ b/chat_app_st.py
@@ -268,6 +268,10 @@ if not st.session_state.get("bot_initialized_successfully", False):
 if "vector_search_ui_warning" in st.session_state and st.session_state.vector_search_ui_warning:
     st.warning(st.session_state.vector_search_ui_warning)
 
+if st.session_state.get("last_gmail_error"):
+    st.error(st.session_state.last_gmail_error)
+    st.session_state.last_gmail_error = ""
+
 # --- Chat History Display ---chat messages from history on app rerun
 if "bot" in st.session_state and hasattr(st.session_state.bot, "chat_history"):
     for message in st.session_state.bot.chat_history: # Use bot's history


### PR DESCRIPTION
## Notes
- Added optional Streamlit import to `email_main` and store API error messages in `st.session_state.last_gmail_error`.
- Displayed Gmail API errors at top of the Streamlit UI.
- New method `get_email_by_id` propagates Gmail errors to the UI state.
- Regression test exercises the error flag.

## Testing
- `pytest tests/test_email_gmail_api.py::TestLastGmailErrorFlag::test_flag_set_on_failure -q` *(fails: ModuleNotFoundError or other dependency errors)*

------
https://chatgpt.com/codex/tasks/task_b_683f153b64188326b9f21dcece79ee37