### PR TITLE
Switch to relative prompt template imports

### DIFF
--- a/api_logging.py
+++ b/api_logging.py
@@ -33,7 +33,7 @@ try:
         fallback_logs_dir = Path("logs") / "gmail_chatbot_api"  # Last resort fallback to local directory
     
     # Try to import from config
-    from email_config import API_LOGS_DIR
+    from gmail_chatbot.email_config import API_LOGS_DIR
     log_dir = API_LOGS_DIR
     print(f"Loaded API_LOGS_DIR from config: {API_LOGS_DIR}")
     

--- a/chat_app_st.py
+++ b/chat_app_st.py
@@ -36,7 +36,7 @@ sys.excepthook = log_exception_to_file
 st.set_page_config(page_title="Gmail Chatbot", layout="wide")
 
 # from email_main import GmailChatbotApp # MOVED
-from email_config import CLAUDE_API_KEY_ENV # Assuming this is accessible
+from gmail_chatbot.email_config import CLAUDE_API_KEY_ENV
 import time
 from pathlib import Path
 import dotenv
@@ -201,7 +201,7 @@ def initialize_chatbot() -> bool:
             st.session_state["initialization_steps"].append(str("Attempting to import GmailChatbotApp..."))
             print("DEBUG: chat_app_st.py - BEFORE GmailChatbotApp import", file=sys.stderr, flush=True)
             try:
-                from email_main import GmailChatbotApp # Deferred import
+                from gmail_chatbot.email_main import GmailChatbotApp
                 print("DEBUG: chat_app_st.py - Import statement for GmailChatbotApp COMPLETED.", file=sys.stderr, flush=True)
                 if not ('GmailChatbotApp' in locals() and isinstance(GmailChatbotApp, type)):
                     critical_msg = "CRITICAL_DEBUG: chat_app_st.py - GmailChatbotApp import issue. Not a class after import."

--- a/email_claude_api.py
+++ b/email_claude_api.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta
 import anthropic
 from gmail_chatbot.email_config import CLAUDE_API_KEY_ENV, CLAUDE_DEFAULT_MODEL, CLAUDE_MAX_TOKENS, LOGS_DIR
 from gmail_chatbot.api_logging import log_claude_request, log_claude_response
-from gmail_chatbot.prompt_templates import format_executable_logic_prompt, VECTOR_RESULTS_EVALUATION_PROMPT
+from .prompt_templates import format_executable_logic_prompt, VECTOR_RESULTS_EVALUATION_PROMPT
 
 print(f"Claude API model in use: {CLAUDE_DEFAULT_MODEL}")
 

--- a/email_config.py
+++ b/email_config.py
@@ -8,7 +8,7 @@ from datetime import date
 # Import the warm functional system message
 # This is imported via a function to avoid circular imports
 def get_warm_functional_system_message():
-    from gmail_chatbot.prompt_templates import WARM_FUNCTIONAL_SYSTEM_MESSAGE
+    from .prompt_templates import WARM_FUNCTIONAL_SYSTEM_MESSAGE
     return WARM_FUNCTIONAL_SYSTEM_MESSAGE
 
 # API configuration

--- a/email_gui.py
+++ b/email_gui.py
@@ -64,7 +64,7 @@ else:
     print("[INFO] GUI_AVAILABLE is False. GUI components will not be loaded. Application behavior depends on main module.")
     tk = None # Define tk as None to prevent NameErrors if parts of the code not guarded by GUI_AVAILABLE try to access tk
 
-from email_config import UI_TITLE, UI_WIDTH, UI_HEIGHT, UI_THEME_COLOR, LOGS_DIR
+from gmail_chatbot.email_config import UI_TITLE, UI_WIDTH, UI_HEIGHT, UI_THEME_COLOR, LOGS_DIR
 
 # Check if vector memory is available - use conditional import
 try:

--- a/email_main.py
+++ b/email_main.py
@@ -113,7 +113,7 @@ from gmail_chatbot import email_vector_db
 from gmail_chatbot.email_memory_vector import EmailVectorMemoryStore
 from gmail_chatbot.enhanced_memory import EnhancedMemoryStore
 from gmail_chatbot.query_classifier import THRESHOLDS
-from gmail_chatbot.prompt_templates import NOTEBOOK_NO_RESULTS_TEMPLATES
+from .prompt_templates import NOTEBOOK_NO_RESULTS_TEMPLATES
 
 # Import ML classifier components
 from gmail_chatbot.ml_classifier.ml_query_classifier import MLQueryClassifier, ClassifierError

--- a/email_memory.py
+++ b/email_memory.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Dict, List, Any, Optional
 from datetime import datetime
 
-from email_config import DATA_DIR
+from gmail_chatbot.email_config import DATA_DIR
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)

--- a/memory_handler.py
+++ b/memory_handler.py
@@ -10,7 +10,7 @@ import threading
 from collections import deque
 
 from gmail_chatbot.email_config import DEFAULT_SYSTEM_MESSAGE
-from gmail_chatbot.prompt_templates import NOTEBOOK_EMPTY_PROMPT, NOTEBOOK_SUMMARY_PREFIX
+from .prompt_templates import NOTEBOOK_EMPTY_PROMPT, NOTEBOOK_SUMMARY_PREFIX
 from gmail_chatbot.preference_detector import PreferenceDetector
 
 

--- a/test_guardrail_direct.py
+++ b/test_guardrail_direct.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 # Import modules to test
-from email_main import GmailChatbotApp
-from prompt_templates import NOTEBOOK_NO_RESULTS_TEMPLATES
+from gmail_chatbot.email_main import GmailChatbotApp
+from gmail_chatbot.prompt_templates import NOTEBOOK_NO_RESULTS_TEMPLATES
 
 def run_test():
     print("Starting notebook guardrail test...")
@@ -32,8 +32,9 @@ def run_test():
     request_id = "test-123"
     
     # Mock the query classification
-    original_classify = __import__('email_main').classify_query_type
-    __import__('email_main').classify_query_type = lambda q: ("notebook_lookup", 0.8, {"notebook_lookup": 0.8})
+    import gmail_chatbot.email_main as email_main
+    original_classify = email_main.classify_query_type
+    email_main.classify_query_type = lambda q: ("notebook_lookup", 0.8, {"notebook_lookup": 0.8})
     
     try:
         # Execute
@@ -77,7 +78,8 @@ def run_test():
         print("\nAll tests completed!")
     finally:
         # Restore original function
-        __import__('email_main').classify_query_type = original_classify
+        import gmail_chatbot.email_main as email_main
+        email_main.classify_query_type = original_classify
 
 if __name__ == "__main__":
     run_test()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ if 'google' not in sys.modules:
     googleapiclient_module = types.ModuleType('googleapiclient')
     googleapiclient_module.discovery = discovery_module
     googleapiclient_module.errors = errors_module
-    sys.modules['google_auth_oauthlib'] = google_auth_oauthlib_module
+    sys.modules['google_auth_oauthlib'] = google_auth_oauthlib
     sys.modules['google_auth_oauthlib.flow'] = flow_module
     sys.modules['googleapiclient'] = googleapiclient_module
     sys.modules['googleapiclient.discovery'] = discovery_module

--- a/tests/test_app_logic.py
+++ b/tests/test_app_logic.py
@@ -14,7 +14,7 @@ sys.path.insert(0, parent_dir)
 
 # Attempt to import the app. This might fail if email_main.py has syntax errors.
 try:
-    from email_main import GmailChatbotApp
+    from gmail_chatbot.email_main import GmailChatbotApp
 except Exception as e:
     print(f"Could not import GmailChatbotApp from email_main: {e}")
     GmailChatbotApp = None # Placeholder if import fails
@@ -44,11 +44,11 @@ def mock_dependencies():
     }
 
 @pytest.mark.skipif(GmailChatbotApp is None, reason="GmailChatbotApp could not be imported from email_main.py")
-@patch('email_main.ClaudeAPIClient') # Path to ClaudeAPIClient where it's instantiated or imported in email_main
-@patch('email_main.GmailAPIClient')  # Path to GmailAPIClient
-@patch('email_main.vector_memory')   # Path to the vector_memory instance
-@patch('email_main.classify_query_type') # Path to classify_query_type function
-@patch('email_main.preference_detector') # Path to preference_detector instance
+@patch('gmail_chatbot.email_main.ClaudeAPIClient')
+@patch('gmail_chatbot.email_main.GmailAPIClient')
+@patch('gmail_chatbot.email_main.vector_memory')
+@patch('gmail_chatbot.email_main.classify_query_type')
+@patch('gmail_chatbot.email_main.preference_detector')
 def test_process_message_general_chat(mock_pref_detector, mock_classify, mock_vec_mem, mock_gmail, mock_claude, mock_dependencies):
     """Test process_message for a general chat scenario."""
     # Setup mocks from the fixture and patches
@@ -88,11 +88,11 @@ def test_process_message_general_chat(mock_pref_detector, mock_classify, mock_ve
     assert app.chat_history[1]["content"] == response
 
 @pytest.mark.skipif(GmailChatbotApp is None, reason="GmailChatbotApp could not be imported from email_main.py")
-@patch('email_main.ClaudeAPIClient')
-@patch('email_main.GmailAPIClient')
-@patch('email_main.vector_memory')
-@patch('email_main.classify_query_type')
-@patch('email_main.preference_detector')
+@patch('gmail_chatbot.email_main.ClaudeAPIClient')
+@patch('gmail_chatbot.email_main.GmailAPIClient')
+@patch('gmail_chatbot.email_main.vector_memory')
+@patch('gmail_chatbot.email_main.classify_query_type')
+@patch('gmail_chatbot.email_main.preference_detector')
 def test_process_message_simple_email_search(mock_pref_detector, mock_classify, mock_vec_mem, mock_gmail, mock_claude, mock_dependencies):
     """Test process_message for a simple email search scenario."""
     mock_claude_client_instance = mock_claude.return_value
@@ -143,10 +143,10 @@ def test_process_message_simple_email_search(mock_pref_detector, mock_classify, 
 
 
 @pytest.mark.skipif(GmailChatbotApp is None, reason="GmailChatbotApp could not be imported from email_main.py")
-@patch('email_main.ClaudeAPIClient')
-@patch('email_main.vector_memory') # Assuming triage fetches emails via vector_memory
-@patch('email_main.classify_query_type')
-@patch('email_main.preference_detector')
+@patch('gmail_chatbot.email_main.ClaudeAPIClient')
+@patch('gmail_chatbot.email_main.vector_memory')
+@patch('gmail_chatbot.email_main.classify_query_type')
+@patch('gmail_chatbot.email_main.preference_detector')
 def test_process_message_triage(mock_pref_detector, mock_classify, mock_vec_mem, mock_claude, mock_dependencies):
     """Test process_message for a triage scenario."""
     mock_claude_client_instance = mock_claude.return_value
@@ -197,10 +197,10 @@ def test_process_message_triage(mock_pref_detector, mock_classify, mock_vec_mem,
 
 
 @pytest.mark.skipif(GmailChatbotApp is None, reason="GmailChatbotApp could not be imported from email_main.py")
-@patch('email_main.ClaudeAPIClient')
-@patch('email_main.classify_query_type') # To ensure it's patched even if not central to this test
-@patch('email_main.preference_detector')
-@patch('email_main.vector_memory') # For find_relevant_preferences
+@patch('gmail_chatbot.email_main.ClaudeAPIClient')
+@patch('gmail_chatbot.email_main.classify_query_type')
+@patch('gmail_chatbot.email_main.preference_detector')
+@patch('gmail_chatbot.email_main.vector_memory')
 def test_process_message_preference_capture(mock_vec_mem, mock_pref_detector, mock_classify, mock_claude, mock_dependencies):
     """Test process_message for a preference capture scenario."""
     mock_claude_client_instance = mock_claude.return_value
@@ -239,12 +239,12 @@ def test_process_message_preference_capture(mock_vec_mem, mock_pref_detector, mo
 
 
 @pytest.mark.skipif(GmailChatbotApp is None, reason="GmailChatbotApp could not be imported from email_main.py")
-@patch('email_main.ClaudeAPIClient') # Patched as it's a common dependency
-@patch('email_main.enhanced_memory') # For app.enhanced_memory_store
-@patch('email_main.vector_memory') # For app.memory_store (used for preferences)
-@patch('email_main.classify_query_type')
-@patch('email_main.preference_detector')
-@patch('email_main.MemoryKind') # To allow referencing MemoryKind.NOTE
+@patch('gmail_chatbot.email_main.ClaudeAPIClient')
+@patch('gmail_chatbot.email_main.enhanced_memory')
+@patch('gmail_chatbot.email_main.vector_memory')
+@patch('gmail_chatbot.email_main.classify_query_type')
+@patch('gmail_chatbot.email_main.preference_detector')
+@patch('gmail_chatbot.email_main.MemoryKind')
 def test_process_message_notebook_lookup(mock_memory_kind, mock_pref_detector, mock_classify, mock_vec_mem, mock_enhanced_mem, mock_claude, mock_dependencies):
     """Test process_message for a notebook_lookup scenario."""
     # mock_claude_client_instance = mock_claude.return_value # Potentially used for formatting or if no notes found

--- a/tests/test_email_search_flow.py
+++ b/tests/test_email_search_flow.py
@@ -12,7 +12,7 @@ if str(parent_dir) not in sys.path:
     sys.path.insert(0, str(parent_dir))
 
 # Import the main application
-from email_main import GmailChatbotApp
+from gmail_chatbot.email_main import GmailChatbotApp
 
 
 class TestEmailSearchFlow:
@@ -32,7 +32,7 @@ class TestEmailSearchFlow:
     @pytest.fixture
     def app(self, mock_gmail_client):
         """Create a test instance of the GmailChatbotApp with mocked dependencies."""
-        with patch('email_main.GmailClient', return_value=mock_gmail_client):
+        with patch('gmail_chatbot.email_main.GmailClient', return_value=mock_gmail_client):
             app = GmailChatbotApp()
             app.gmail_client = mock_gmail_client
             app.cl_client = MagicMock()  # Mock Claude client
@@ -75,7 +75,7 @@ class TestEmailSearchFlow:
         
     def test_heuristic_override_logging(self, app, mock_gmail_client):
         """Test that the heuristic override is logged properly."""
-        with patch('email_main.logging.info') as mock_logging:
+        with patch('gmail_chatbot.email_main.logging.info') as mock_logging:
             # Use a query that might have been misclassified before
             query = "Did I receive any emails today?"
             app.process_message(query)

--- a/tests/test_notebook_guardrail.py
+++ b/tests/test_notebook_guardrail.py
@@ -18,9 +18,9 @@ if parent_dir not in sys.path:
     sys.path.insert(0, parent_dir)
 
 # Import modules to test
-from email_main import GmailChatbotApp
-from prompt_templates import NOTEBOOK_NO_RESULTS_TEMPLATES
-from email_config import CLAUDE_API_KEY_ENV
+from gmail_chatbot.email_main import GmailChatbotApp
+from gmail_chatbot.prompt_templates import NOTEBOOK_NO_RESULTS_TEMPLATES
+from gmail_chatbot.email_config import CLAUDE_API_KEY_ENV
 
 
 @pytest.fixture
@@ -31,12 +31,12 @@ def mock_deps(monkeypatch):
     gmail_client = MagicMock()
     claude_client = MagicMock()
 
-    monkeypatch.setattr('email_main.GmailAPIClient', lambda *a, **k: gmail_client)
-    monkeypatch.setattr('email_main.ClaudeAPIClient', lambda *a, **k: claude_client)
-    monkeypatch.setattr('email_main.EmailVectorMemoryStore', lambda *a, **k: memory_store)
-    monkeypatch.setattr('email_main.EnhancedMemoryStore', MagicMock(return_value=MagicMock()))
-    monkeypatch.setattr('email_main.PreferenceDetector', MagicMock(return_value=MagicMock()))
-    monkeypatch.setattr('email_main.MemoryActionsHandler', MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr('gmail_chatbot.email_main.GmailAPIClient', lambda *a, **k: gmail_client)
+    monkeypatch.setattr('gmail_chatbot.email_main.ClaudeAPIClient', lambda *a, **k: claude_client)
+    monkeypatch.setattr('gmail_chatbot.email_main.EmailVectorMemoryStore', lambda *a, **k: memory_store)
+    monkeypatch.setattr('gmail_chatbot.email_main.EnhancedMemoryStore', MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr('gmail_chatbot.email_main.PreferenceDetector', MagicMock(return_value=MagicMock()))
+    monkeypatch.setattr('gmail_chatbot.email_main.MemoryActionsHandler', MagicMock(return_value=MagicMock()))
     
     app = GmailChatbotApp()
     app.memory_store = memory_store
@@ -73,7 +73,7 @@ def test_notebook_guardrail_entity_extraction(mock_deps, query, expected_entity,
     memory_store = mock_deps['memory_store']
     
     # Mock the classifier to always return notebook_lookup
-    monkeypatch.setattr('email_main.classify_query_type', 
+    monkeypatch.setattr('gmail_chatbot.email_main.classify_query_type',
                          lambda q: ("notebook_lookup", 0.8, {"notebook_lookup": 0.8}))
     
     # Setup - notebook lookup returns empty results
@@ -98,7 +98,7 @@ def test_notebook_guardrail_empty_results(mock_deps, monkeypatch):
     claude_client = mock_deps['claude_client']
     
     # Mock the classifier to always return notebook_lookup
-    monkeypatch.setattr('email_main.classify_query_type', 
+    monkeypatch.setattr('gmail_chatbot.email_main.classify_query_type',
                          lambda q: ("notebook_lookup", 0.8, {"notebook_lookup": 0.8}))
     
     # Setup - notebook lookup returns empty results
@@ -126,7 +126,7 @@ def test_notebook_guardrail_with_results(mock_deps, monkeypatch):
     claude_client = mock_deps['claude_client']
     
     # Mock the classifier to always return notebook_lookup
-    monkeypatch.setattr('email_main.classify_query_type', 
+    monkeypatch.setattr('gmail_chatbot.email_main.classify_query_type',
                          lambda q: ("notebook_lookup", 0.8, {"notebook_lookup": 0.8}))
     
     # Setup - notebook lookup returns non-empty results


### PR DESCRIPTION
## Summary
- use relative import for `WARM_FUNCTIONAL_SYSTEM_MESSAGE`
- switch other modules to relative imports from `prompt_templates`
- update internal imports to reference `gmail_chatbot.email_config`
- fix google oauth stub typo in tests
- update tests to import modules from the package

## Testing
- `pytest -q` *(fails: TypeError in GmailChatbotApp)*
- `streamlit run chat_app_st.py --server.headless true --server.port 8501` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683fac74aa1883268770fcc4d0f65f1e