### PR TITLE
Fix oauthlib alias in conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,8 @@ if 'google' not in sys.modules:
     flow_module.InstalledAppFlow = MagicMock()
     google_auth_oauthlib = types.ModuleType('google_auth_oauthlib')
     google_auth_oauthlib.flow = flow_module
-    sys.modules['google_auth_oauthlib'] = google_auth_oauthlib
+    google_auth_oauthlib_module = google_auth_oauthlib
+    sys.modules['google_auth_oauthlib'] = google_auth_oauthlib_module
     sys.modules['google_auth_oauthlib.flow'] = flow_module
 
 
@@ -59,7 +60,7 @@ if 'google' not in sys.modules:
     googleapiclient_module = types.ModuleType('googleapiclient')
     googleapiclient_module.discovery = discovery_module
     googleapiclient_module.errors = errors_module
-    sys.modules['google_auth_oauthlib'] = google_auth_oauthlib
+    sys.modules['google_auth_oauthlib'] = google_auth_oauthlib_module
     sys.modules['google_auth_oauthlib.flow'] = flow_module
     sys.modules['googleapiclient'] = googleapiclient_module
     sys.modules['googleapiclient.discovery'] = discovery_module


### PR DESCRIPTION
## Summary
- create variable for google_auth_oauthlib module
- reference alias when registering module stubs

## Testing
- `pytest -q` *(fails: 38 failed, 27 passed, 10 errors)*

------
https://chatgpt.com/codex/tasks/task_b_683faea834a48326820f2f35936d901c