### PR TITLE
Add formatting & lint tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+        args: ["--line-length=79"]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.1
+    hooks:
+      - id: ruff
+        args: ["--line-length=79"]

--- a/README.md
+++ b/README.md
@@ -213,6 +213,17 @@ pytest -q
 If heavy optional dependencies such as FAISS are not available, some tests will
 be skipped automatically.
 
+## Code Formatting and Linting
+
+Format code with [black](https://github.com/psf/black) and run
+[ruff](https://github.com/astral-sh/ruff) to lint:
+
+```bash
+black .
+
+ruff .
+```
+
 ## License
 
 This project is for personal use only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,24 @@ requires-python = ">=3.8"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["gmail_chatbot*"]
+
+[tool.black]
+line-length = 79
+target-version = ["py38"]
+exclude = """
+/(
+    build
+  | dist
+  | data
+  | test_vector_cache
+)/
+"""
+
+[tool.ruff]
+line-length = 79
+exclude = [
+    "build",
+    "dist",
+    "data",
+    "test_vector_cache",
+]


### PR DESCRIPTION
## Summary
- configure `black` and `ruff` in `pyproject.toml`
- document code formatting and linting commands in README
- add `.pre-commit-config.yaml` using black and ruff

## Testing
- `ruff check .` *(fails: many lint errors)*
- `pytest -q` *(fails: 38 failed, 27 passed, 46 warnings, 10 errors)*
- `pre-commit run --files pyproject.toml README.md .pre-commit-config.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683fb07e97948326bc10606a020946db