### PR TITLE
Fix import paths after refactor

### DIFF
--- a/chat_app_st.py
+++ b/chat_app_st.py
@@ -8,8 +8,8 @@ import time
 import json
 from pathlib import Path
 import dotenv
-from agentic_planner import generate_plan
-from agentic_executor import (
+from gmail_chatbot.agentic_planner import generate_plan
+from gmail_chatbot.agentic_executor import (
     execute_step,
     summarize_and_log_agentic_results,  # Added for agentic execution
     handle_step_limit_reached,


### PR DESCRIPTION
## Summary
- update `chat_app_st` to import agentic modules from `gmail_chatbot`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError and environment issues)*

------
https://chatgpt.com/codex/tasks/task_b_683fb9bd1a28832680a2877e1d1cc0fa