### PR TITLE
Replace print statements with logging

### DIFF
--- a/gmail_chatbot/email_gmail_api.py
+++ b/gmail_chatbot/email_gmail_api.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-print("Loading updated email_gmail_api module with API logging - v" + str(hex(id(object))))
 
 import os
 import base64
@@ -32,6 +31,9 @@ logging.basicConfig(
         logging.StreamHandler()
     ]
 )
+
+logger = logging.getLogger(__name__)
+logger.debug("email_gmail_api module loaded")
 
 class GmailAPIClient:
     """Client for interacting with Gmail API with Claude assistance."""

--- a/gmail_chatbot/email_vector_db.py
+++ b/gmail_chatbot/email_vector_db.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import sys
-print("DEBUG: email_vector_db.py - TOP OF FILE EXECUTION", file=sys.stderr)
 try:
     _ = 1 # Dummy operation to ensure try block has content
 except Exception as e:
@@ -83,6 +82,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 logging.getLogger("faiss.loader").setLevel(logging.WARNING)
 logging.getLogger("torch").setLevel(logging.ERROR)
+logger.debug("email_vector_db.py loaded")
 
 # Try to import required dependencies
 try:
@@ -103,10 +103,8 @@ try:
     logger.info(
         "FAISS GPU acceleration explicitly disabled. Running in CPU-only mode."
     )
-    print(
-        "DEBUG: email_vector_db.py - FAISS GPU_AVAILABLE explicitly set to False.",
-        file=sys.stderr,
-    )
+    logger.debug(
+        "email_vector_db.py - FAISS GPU_AVAILABLE explicitly set to False.")
 
     # Ensure 'langchain-huggingface' is installed in your environment
     from langchain_huggingface import HuggingFaceEmbeddings
@@ -727,17 +725,20 @@ This should be indexed and retrievable by semantic or keyword search.""",
         tags=["test", "email"]
     )
     
-    print(f"Email added: {result}")
+    logger.info("Email added: %s", result)
     
     # Test search functionality
     search_results = test_db.search("vector database", num_results=2)
     
-    print(f"Search results: {len(search_results)}")
+    logger.info("Search results: %d", len(search_results))
     for i, result in enumerate(search_results):
-        print(f"""Result {i+1}:
-  Content: {result['content'][:100]}...
-  Similarity: {result['similarity']:.4f}
-  Search type: {result['search_type']}""")
+        logger.info(
+            "Result %d: Content: %s... Similarity: %.4f Search type: %s",
+            i + 1,
+            result['content'][:100],
+            result['similarity'],
+            result['search_type'],
+        )
     
     # Test with filters
     filtered_results = test_db.search(
@@ -745,12 +746,11 @@ This should be indexed and retrievable by semantic or keyword search.""",
         filters={"sender": "sender@example.com"}
     )
     
-    print(f"Filtered results: {len(filtered_results)}")
+    logger.info("Filtered results: %d", len(filtered_results))
     
     # Print status
     status = test_db.get_status()
-    print(f"""Vector DB Status:
-{json.dumps(status, indent=2)}""")
+    logger.info("Vector DB Status:\n%s", json.dumps(status, indent=2))
 
 
 def reindex_all_emails():
@@ -814,9 +814,9 @@ if __name__ == "__main__":
         test_email_vector_db()
     else:
         # If no arguments provided, show status and instructions
-        print("\nEmail Vector Database Status:")
+        logger.info("\nEmail Vector Database Status:")
         for key, value in status.items():
-            print(f"  {key}: {value}")
-        print("\nTo rebuild the index: python -m gmail_chatbot.email_vector_db --reindex")
-        print("To run tests: python -m gmail_chatbot.email_vector_db --test")
+            logger.info("  %s: %s", key, value)
+        logger.info("\nTo rebuild the index: python -m gmail_chatbot.email_vector_db --reindex")
+        logger.info("To run tests: python -m gmail_chatbot.email_vector_db --test")
 

--- a/gmail_chatbot/gui/core.py
+++ b/gmail_chatbot/gui/core.py
@@ -20,11 +20,10 @@ def can_initialize_gui() -> bool:
         # Attempt to import tkinter. This is the first point of failure if not installed.
         import tkinter as tk_local
     except ImportError as e:
-        error_msg = f"GUI environment check: Tkinter module import failed: {e}. Ensure Tkinter is installed."
-        print(f"[ERROR] {error_msg}")
-        # Logging might not be fully configured here, but attempt it.
-        if logging.getLogger().hasHandlers():
-            logging.error(error_msg)
+        error_msg = (
+            f"GUI environment check: Tkinter module import failed: {e}. Ensure Tkinter is installed."
+        )
+        logging.error(error_msg)
         return False
 
     try:
@@ -33,21 +32,19 @@ def can_initialize_gui() -> bool:
         root = tk_local.Tk()
         root.withdraw()  # Make it invisible, don't show on screen
         root.destroy()   # Cleanly destroy it
-        print("[INFO] GUI environment check: Tkinter initialized successfully.")
-        if logging.getLogger().hasHandlers():
-            logging.info("[INFO] GUI environment check: Tkinter initialized successfully.")
+        logging.info("GUI environment check: Tkinter initialized successfully.")
         return True
     except tk_local.TclError as e: # Catch specific Tcl errors often related to display
-        error_msg = f"GUI environment check: Tkinter TclError: {e}. This often means no display is available or X server is misconfigured."
-        print(f"[ERROR] {error_msg}")
-        if logging.getLogger().hasHandlers():
-            logging.error(error_msg)
+        error_msg = (
+            f"GUI environment check: Tkinter TclError: {e}. This often means no display is available or X server is misconfigured."
+        )
+        logging.error(error_msg)
         return False
     except Exception as e: # Catch any other unexpected errors during Tkinter initialization
-        error_msg = f"GUI environment check: Failed to initialize Tkinter due to an unexpected error: {e}"
-        print(f"[ERROR] {error_msg}")
-        if logging.getLogger().hasHandlers():
-            logging.error(error_msg)
+        error_msg = (
+            f"GUI environment check: Failed to initialize Tkinter due to an unexpected error: {e}"
+        )
+        logging.error(error_msg)
         return False
 
 # Determine GUI availability by calling the check function.
@@ -62,7 +59,9 @@ if GUI_AVAILABLE:
 else:
     # Error messages are printed by can_initialize_gui().
     # Logging is also attempted by can_initialize_gui().
-    print("[INFO] GUI_AVAILABLE is False. GUI components will not be loaded. Application behavior depends on main module.")
+    logging.info(
+        "GUI_AVAILABLE is False. GUI components will not be loaded. Application behavior depends on main module."
+    )
     tk = None # Define tk as None to prevent NameErrors if parts of the code not guarded by GUI_AVAILABLE try to access tk
 
 from gmail_chatbot.email_config import UI_TITLE, UI_WIDTH, UI_HEIGHT, UI_THEME_COLOR, LOGS_DIR


### PR DESCRIPTION
## Summary
- convert API logging prints to `logger` usage
- use logger in `email_vector_db` and `email_gmail_api`
- log GUI availability status
- clean up GUI environment check

## Testing
- `pytest -q` *(fails: ANTHROPIC_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_b_683fbf17d23083268244acf5185d55ee