### PR TITLE
Update docs with Streamlit guidance

### DIFF
--- a/AGENTS.MD
+++ b/AGENTS.MD
@@ -104,3 +104,12 @@ Adherence to these standards is crucial for maintaining code quality, readabilit
 -   **Tool Usage:** When using tools (e.g., `edit_file`, `run_command`), ensure your actions align with the project's structure, coding standards, and testing procedures outlined herein.
 -   **Memory Utilization:** Actively use and refer to project-specific memories provided during our interactions to maintain continuity and adhere to established patterns or decisions.
 -   **Clarification:** If any instruction in this document or a user request is ambiguous, seek clarification before proceeding.
+
+## 9. Streamlit Development Guidelines
+
+- Structure Streamlit apps so the UI (e.g., `chat_app_st.py`) is thin and imports reusable utilities from modules like `utils/llm.py` or `utils/prompt.py`.
+- Preserve conversation context using `st.session_state`; persist this data externally for multi-user or long-term sessions.
+- Use asynchronous API calls and `st.write_stream` to keep the UI responsive.
+- Apply `st.cache_resource` or `st.cache_data` for expensive operations, and include rate limiting when invoking LLM or Gmail APIs.
+- Leverage observability tools such as LangSmith to debug agent reasoning.
+- Prompt templates and few-shot examples should guide tool usage, and self-correction loops can improve reliability.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ pip install -r requirements-lite.txt
 - "Find any emails mentioning the client meeting scheduled for tomorrow"
 - "Search for emails with the subject containing 'quarterly report'"
 
+## Streamlit Usage & Best Practices
+
+The main application `chat_app_st.py` demonstrates Streamlit chat widgets such as `st.chat_message` and `st.chat_input` for conversational interaction. Prompt parameters can be tuned via UI controls like sliders, and responses stream back through `st.write_stream` to keep the interface responsive.
+
+Short-term conversation state lives in `st.session_state`; for long-term or multi-user deployments, store history in external persistence (e.g., an EFS volume or database). When running at scale, containerize the app and place it behind a load balancer, applying caching and rate limiting to avoid hitting API quotas.
+
+Agentic features use structured prompt templates and few-shot tool examples, allowing the chatbot to reason about tasks and self-correct when necessary.
+
 ## Privacy and Security
 
 - All email content is processed locally on your machine


### PR DESCRIPTION
## Summary
- add Streamlit usage section in README
- document Streamlit development guidelines in AGENTS

## Testing
- `pytest -q` *(fails: ANTHROPIC_API_KEY environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_b_683fbfee05c08326979443689a9b3a9f