### PR TITLE
Centralize logging init

### DIFF
--- a/gmail_chatbot/disk_store.py
+++ b/gmail_chatbot/disk_store.py
@@ -34,7 +34,6 @@ except Exception:  # pragma: no cover - simplified fallback for test env
     portalocker = _DummyPortalocker()
 
 # Set up logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Type for data stored in DiskStore

--- a/gmail_chatbot/email_vector_db.py
+++ b/gmail_chatbot/email_vector_db.py
@@ -78,7 +78,6 @@ EMBEDDING_MODEL_NAME = "test-embeddings"
 DEFAULT_CACHE_DIR = os.path.join(DATA_DIR, "vector_cache")
 
 # Configure logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 logging.getLogger("faiss.loader").setLevel(logging.WARNING)
 logging.getLogger("torch").setLevel(logging.ERROR)


### PR DESCRIPTION
## Summary
- remove redundant logging setup from modules
- use module loggers via `logging.getLogger(__name__)`
- rely on `configure_safe_logging` in the app for logging initialization

## Testing
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_683fc11457b883269b62d7aa50f19d05