### PR TITLE
Fix log_gmail_response return path logic

### DIFF
--- a/gmail_chatbot/api_logging.py
+++ b/gmail_chatbot/api_logging.py
@@ -394,15 +394,3 @@ def log_gmail_response(request_log_path: str,
         traceback.print_exc()
         # Fail fast - raise the exception to make errors visible
         raise
-    response_data = {
-        "email_count": email_count,
-        "emails": simplified_metadata,
-        "related_request": request_log_path
-    }
-    
-    return log_api_interaction(
-        interaction_type="gmail_response",
-        request_data={"related_request": request_log_path},
-        response_data=response_data,
-        error=error
-    )

--- a/tests/test_api_logging.py
+++ b/tests/test_api_logging.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+import unittest
+
+# Add project root to path for imports
+parent_dir = Path(__file__).parent.parent
+if str(parent_dir) not in sys.path:
+    sys.path.insert(0, str(parent_dir))
+
+from gmail_chatbot import api_logging
+
+
+class TestLogGmailResponse(unittest.TestCase):
+    """Tests for the log_gmail_response function."""
+
+    def test_returns_path_from_log_api_interaction(self):
+        """Verify return path from log_api_interaction."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.object(api_logging, "API_LOGS_DIR", Path(tmpdir)):
+                with patch.object(
+                    api_logging,
+                    "ensure_log_directory_exists",
+                ) as mock_ensure_dir, patch.object(
+                    api_logging,
+                    "log_api_interaction",
+                    return_value="test_path",
+                ) as mock_log_interaction:
+                    result = api_logging.log_gmail_response(
+                        "request.json",
+                        1,
+                        [{"id": "1", "body": "test body"}]
+                    )
+
+                    self.assertEqual(result, "test_path")
+                    mock_log_interaction.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- remove unreachable code in `log_gmail_response`
- add unit test for `log_gmail_response` path return

## Testing
- `pytest -q` *(fails: 38 failed, 28 passed, 46 warnings, 10 errors)*

------
https://chatgpt.com/codex/tasks/task_b_683fc25990948326b7041597049db47d