### PR TITLE
Improve env loading helper

### DIFF
--- a/chat_app_st.py
+++ b/chat_app_st.py
@@ -7,7 +7,6 @@ import io
 import time
 import json
 from pathlib import Path
-import dotenv
 from gmail_chatbot.agentic_planner import generate_plan
 from gmail_chatbot.agentic_executor import (
     execute_step,
@@ -36,10 +35,7 @@ sys.excepthook = log_exception_to_file
 st.set_page_config(page_title="Gmail Chatbot", layout="wide")
 
 # from email_main import GmailChatbotApp # MOVED
-from gmail_chatbot.email_config import CLAUDE_API_KEY_ENV
-import time
-from pathlib import Path
-import dotenv
+from gmail_chatbot.email_config import CLAUDE_API_KEY_ENV, load_env
 
 st.title("✉️ Gmail Claude Chatbot Assistant")
 
@@ -172,13 +168,18 @@ def initialize_chatbot() -> bool:
     """Attempts to initialize the chatbot application, returns True on success, False on failure."""
     st.session_state["initialization_steps"] = [] # Initialize early, done before any potential failure point
 
-    # Load .env file before checking for the API key
-    dotenv_path = Path(__file__).resolve().parent / ".env"
-    if dotenv_path.exists():
-        dotenv.load_dotenv(dotenv_path)
-        st.session_state["initialization_steps"].append(str(f"✓ .env file loaded from {dotenv_path}"))
+    env_path = Path(__file__).resolve().parent / ".env"
+    load_env()
+    if env_path.exists():
+        st.session_state["initialization_steps"].append(
+            str(f"✓ .env file loaded from {env_path}")
+        )
     else:
-        st.session_state["initialization_steps"].append(str(f"⚠️ .env file not found at {dotenv_path}. Some features might not work."))
+        st.session_state["initialization_steps"].append(
+            str(
+                f"⚠️ .env file not found at {env_path}. Some features might not work."
+            )
+        )
         # This might not be critical enough to stop, depending on what's in .env, but API key check below is.
 
     # Check for Anthropic API key before attempting to initialize

--- a/gmail_chatbot/email_config.py
+++ b/gmail_chatbot/email_config.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import logging
 import os
 from pathlib import Path
 from datetime import date
@@ -32,6 +33,20 @@ os.makedirs(DATA_DIR, exist_ok=True)
 os.makedirs(LOGS_DIR, exist_ok=True)
 os.makedirs(GLOBAL_LOGS_DIR, exist_ok=True)
 os.makedirs(API_LOGS_DIR, exist_ok=True)
+
+# Environment handling
+def load_env() -> None:
+    """Load environment variables from a .env file in the project root."""
+    try:
+        import dotenv
+    except ImportError:  # pragma: no cover - optional dependency
+        return
+
+    env_path = PROJECT_DIR / ".env"
+    if env_path.exists():
+        dotenv.load_dotenv(env_path)
+    else:
+        logging.warning(f"Environment file not found at {env_path}")
 
 # Claude API configuration
 CLAUDE_DEFAULT_MODEL = "claude-3-7-sonnet-20250219"

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -114,15 +114,14 @@ def dummy_email_main(monkeypatch):
 
     module.GmailChatbotApp = DummyGmailChatbotApp
     monkeypatch.setitem(sys.modules, "email_main", module)
+    monkeypatch.setitem(sys.modules, "gmail_chatbot.email_main", module)
     yield module
     sys.modules.pop("email_main", None)
 
 
 def _load_chat_app():
-    if 'dotenv' not in sys.modules:
-        dotmod = types.ModuleType('dotenv')
-        dotmod.load_dotenv = lambda *a, **k: None
-        sys.modules['dotenv'] = dotmod
+    import gmail_chatbot.email_config as email_config
+    email_config.load_env = lambda *a, **k: None
     if "chat_app_st" in sys.modules:
         del sys.modules["chat_app_st"]
     return importlib.import_module("chat_app_st")


### PR DESCRIPTION
## Summary
- centralize dotenv logic in `email_config.load_env`
- use `load_env` in core startup and Streamlit app
- patch `load_env` in initialization tests
- make `process_message` accept optional request ID

## Testing
- `pytest tests/test_initialization.py -q`

------
https://chatgpt.com/codex/tasks/task_b_683fc42792008326b12a4dbe25fbb509