### PR TITLE
Fix README auth section

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,10 @@ Agentic features use structured prompt templates and few-shot tool examples, all
 If you encounter authentication errors with Gmail API:
 
 1. Delete the `token.json` file in the project-root `data/` directory
-2. Restart the application and go through the authentication flow again
+2. Confirm that `data/client_secret.json` exists and is correctly named
+3. Restart the application and go through the authentication flow again
+
+Missing or misnamed credentials can prevent the OAuth authorization window from appearing.
 
 ### API Key Issues
 


### PR DESCRIPTION
## Summary
- clarify Gmail API authentication steps

## Testing
- `pytest -q` *(fails: 31 failed, 39 passed, 10 errors)*

------
https://chatgpt.com/codex/tasks/task_b_683fd9c07a6883269d008e59e4a9d450