### PR TITLE
Fix ML classifier model path

### DIFF
--- a/gmail_chatbot/app/core.py
+++ b/gmail_chatbot/app/core.py
@@ -217,9 +217,9 @@ class GmailChatbotApp:
                 f"Found {CLAUDE_API_KEY_ENV} in environment variables."
             )
 
-        # Define path for the ML model
+        # Define path for the ML model relative to the project root
         MODEL_PATH = (
-            Path(__file__).resolve().parent
+            Path(__file__).resolve().parents[1]
             / "ml_classifier"
             / "classifier_model.joblib"
         )


### PR DESCRIPTION
## Summary
- update the ML model path constant to reference the correct `ml_classifier` directory
- clarify in code that the path is relative to the project root

## Testing
- `pytest -q` *(fails: ValueError for missing ANTHROPIC_API_KEY and other test failures)*

------
https://chatgpt.com/codex/tasks/task_b_683fd9aee1a8832689a75e0479efc007