### PR TITLE
Remove module logging.basicConfig usage

### DIFF
--- a/gmail_chatbot/email_claude_api.py
+++ b/gmail_chatbot/email_claude_api.py
@@ -12,7 +12,7 @@ import logging
 from datetime import datetime, timedelta
 
 import anthropic
-from gmail_chatbot.email_config import CLAUDE_API_KEY_ENV, CLAUDE_DEFAULT_MODEL, CLAUDE_MAX_TOKENS, LOGS_DIR
+from gmail_chatbot.email_config import CLAUDE_API_KEY_ENV, CLAUDE_DEFAULT_MODEL, CLAUDE_MAX_TOKENS
 from gmail_chatbot.api_logging import log_claude_request, log_claude_response
 from .prompt_templates import format_executable_logic_prompt, VECTOR_RESULTS_EVALUATION_PROMPT
 
@@ -23,17 +23,10 @@ import io
 
 # Configure stdout/stderr for UTF-8 to properly handle emojis in console output
 if not os.environ.get("PYTEST_RUNNING"):
-    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
-    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8")
 
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler(LOGS_DIR / f"claude_api_{datetime.now().strftime('%Y%m%d')}.log", encoding='utf-8'),
-        logging.StreamHandler(sys.stdout)
-    ]
-)
+logger = logging.getLogger(__name__)
 
 class ClaudeAPIClient:
     """Client for interacting with Claude API to process email queries and responses."""

--- a/gmail_chatbot/email_memory.py
+++ b/gmail_chatbot/email_memory.py
@@ -11,7 +11,6 @@ from datetime import datetime
 from gmail_chatbot.email_config import DATA_DIR
 
 # Set up logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/gmail_chatbot/email_memory_vector.py
+++ b/gmail_chatbot/email_memory_vector.py
@@ -14,7 +14,6 @@ from gmail_chatbot.email_memory import EmailMemoryStore
 from gmail_chatbot.email_vector_db import vector_db, VECTOR_LIBS_AVAILABLE
 
 # Set up logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/gmail_chatbot/enhanced_memory.py
+++ b/gmail_chatbot/enhanced_memory.py
@@ -23,7 +23,6 @@ except ImportError:
     vector_db = None
 
 # Set up logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/gmail_chatbot/ml_classifier/ml_query_classifier.py
+++ b/gmail_chatbot/ml_classifier/ml_query_classifier.py
@@ -23,8 +23,6 @@ import numpy as np
 from pathlib import Path
 
 
-# Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
 

--- a/gmail_chatbot/ml_classifier/test_integration.py
+++ b/gmail_chatbot/ml_classifier/test_integration.py
@@ -9,11 +9,7 @@ import sys
 from pathlib import Path
 import logging
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
+logger = logging.getLogger(__name__)
 
 # Add Gmail chatbot path
 MODULE_DIR = Path(__file__).parent

--- a/gmail_chatbot/ml_classifier/update_classifier.py
+++ b/gmail_chatbot/ml_classifier/update_classifier.py
@@ -28,7 +28,6 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from ml_classifier.preference_training_data import get_preference_training_data, get_non_preference_examples
 
 # Set up logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
 # Define paths

--- a/gmail_chatbot/ml_classifier/verify_model.py
+++ b/gmail_chatbot/ml_classifier/verify_model.py
@@ -10,11 +10,6 @@ import sys
 import logging
 from pathlib import Path
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
 logger = logging.getLogger(__name__)
 
 

--- a/gmail_chatbot/preference_detector.py
+++ b/gmail_chatbot/preference_detector.py
@@ -18,7 +18,6 @@ from gmail_chatbot.query_classifier import classify_query_type
 from gmail_chatbot.enhanced_memory import EnhancedMemoryStore
 
 # Set up logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 

--- a/scripts/verify_logging.py
+++ b/scripts/verify_logging.py
@@ -14,12 +14,7 @@ from pathlib import Path
 import json
 import traceback
 
-# Configure basic logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='[%(asctime)s] [%(levelname)s] %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S'
-)
+logger = logging.getLogger(__name__)
 
 # Add project root directory to path to allow imports
 script_dir = Path(__file__).resolve().parent


### PR DESCRIPTION
## Summary
- drop `logging.basicConfig` calls from modules
- acquire loggers with `logging.getLogger(__name__)`

## Testing
- `pytest -q` *(fails: ANTHROPIC_API_KEY required, disk store thread tests, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_683fd9bf3d988326a854a90de4f0e928