### PR TITLE
Fix path resolution for data and logs

### DIFF
--- a/gmail_chatbot/api_logging.py
+++ b/gmail_chatbot/api_logging.py
@@ -26,7 +26,8 @@ try:
     # Get the project root directory
     try:
         from pathlib import Path
-        project_root = Path(__file__).resolve().parents[2]
+        # Determine the project root (one level above the package)
+        project_root = Path(__file__).resolve().parents[1]
         logs_dir_base = project_root / "logs"
         fallback_logs_dir = logs_dir_base / "gmail_chatbot_api"
         logger.debug("Determined fallback logs directory: %s", fallback_logs_dir)

--- a/gmail_chatbot/app/core.py
+++ b/gmail_chatbot/app/core.py
@@ -129,7 +129,8 @@ from gmail_chatbot.memory_writers import (
 )
 
 # Set up the logs directory path
-LOGS_DIR = Path(__file__).resolve().parents[3] / "logs" / "gmail_chatbot"
+# Store logs under the project root instead of outside the repository
+LOGS_DIR = Path(__file__).resolve().parents[2] / "logs" / "gmail_chatbot"
 os.makedirs(LOGS_DIR, exist_ok=True)
 
 # Provide a placeholder for tests that patch this attribute

--- a/gmail_chatbot/email_claude_api.py
+++ b/gmail_chatbot/email_claude_api.py
@@ -39,7 +39,8 @@ class ClaudeAPIClient:
         """
         try:
             # Get the project root directory for better error messages
-            project_root = Path(__file__).resolve().parents[2]
+            # Determine project root for locating the .env file
+            project_root = Path(__file__).resolve().parents[1]
             env_path = project_root / ".env"
             
             self.api_key = os.environ.get(CLAUDE_API_KEY_ENV)

--- a/gmail_chatbot/email_config.py
+++ b/gmail_chatbot/email_config.py
@@ -22,7 +22,8 @@ GMAIL_SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]
 
 # File paths
 BASE_DIR = Path(__file__).resolve().parent
-PROJECT_DIR = Path(__file__).resolve().parents[2]
+# The project root is one level above this module's package
+PROJECT_DIR = Path(__file__).resolve().parents[1]
 DATA_DIR = PROJECT_DIR / "data"
 LOGS_DIR = BASE_DIR / "logs"
 GLOBAL_LOGS_DIR = PROJECT_DIR / "logs"


### PR DESCRIPTION
## Summary
- ensure project root is correctly resolved one directory above package
- use the corrected project path when determining log and credential locations

## Testing
- `pytest -q` *(fails: SyntaxError in scripts/test_guardrail_direct.py)*

------
https://chatgpt.com/codex/tasks/task_b_683fdbe14b308326a74c85b14fce7016