### PR TITLE
Fix agentic state default

### DIFF
--- a/chat_app_st.py
+++ b/chat_app_st.py
@@ -44,7 +44,7 @@ st.title("✉️ Gmail Claude Chatbot Assistant")
 default_agentic_state_values = {
     "current_step_index": 0,
     "executed_call_count": 0,
-    "accumulated_results": [],
+    "accumulated_results": {},
     "error_messages": []
 }
 if "agentic_mode_enabled" not in st.session_state:


### PR DESCRIPTION
## Summary
- ensure `default_agentic_state_values['accumulated_results']` starts as a dict

## Testing
- `pytest -q` *(fails: ValueError for missing ANTHROPIC_API_KEY and other test failures)*

------
https://chatgpt.com/codex/tasks/task_b_683fdf7040488326a5e691f662885a1b