### PR TITLE
Add agentic step logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Added robust chat initialization guard-rail to Streamlit app to prevent premature user interaction
 - Implemented detailed step-by-step initialization diagnostics in chat_app_st.py to provide clear error information
 - Added Continue/Stop prompt when autonomous step limit is reached
+- INFO level logs for agentic step execution now written to
+  `logs/gmail_chatbot/` for troubleshooting
 
 ### Changed
 


### PR DESCRIPTION
## Summary
- emit info-level logs in `execute_step` and `run_agentic_plan`
- include state summaries after each step and log parse errors
- document log location in `CHANGELOG`

## Testing
- `pytest -q` *(fails: anthropic key and other dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_b_683fef5065b08326870412a52a496c6d