### PR TITLE
Adjust email search patterns and classification

### DIFF
--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -22,6 +22,7 @@ from gmail_chatbot.query_classifier import classify_query_type
         ("Show me what hit my inbox yesterday", "email_search"),
         ("Check my inbox for new messages", "email_search"),
         ("Catch me up on what I missed in my inbox", "email_search"),
+        ("Can you check todays email?", "email_search"),
         
         # Guard-rail heuristic should catch these
         ("Did I get any emails today?", "email_search"),


### PR DESCRIPTION
## Summary
- expand email search phrases to include "todays email" variants
- promote low scoring email search matches instead of marking them ambiguous
- cover "Can you check todays email?" in classifier tests

## Testing
- `pytest -q` *(fails: could not install required dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_683ff02327648326b8f83499fbdc69ab