### PR TITLE
Add Gmail search regex and update tests

### DIFF
--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -23,6 +23,8 @@ from gmail_chatbot.query_classifier import classify_query_type
         ("Check my inbox for new messages", "email_search"),
         ("Catch me up on what I missed in my inbox", "email_search"),
         ("Can you check todays email?", "email_search"),
+        ("search Gmail for from:bryce@example.com", "email_search"),
+        ("check today's email", "email_search"),
         
         # Guard-rail heuristic should catch these
         ("Did I get any emails today?", "email_search"),

--- a/tests/test_email_search_flow.py
+++ b/tests/test_email_search_flow.py
@@ -43,9 +43,11 @@ class TestEmailSearchFlow:
             # Direct email search queries
             "Show me emails from John",
             "Search my inbox for invoices",
+            "search Gmail for from:bryce@example.com",
             
             # Inbox check queries that should be routed to email_search
             "Did I receive any emails today?",
+            "check today's email",
             "Check my inbox for new messages",
             "Have I got mail today?",
             "Any new messages in my inbox?",


### PR DESCRIPTION
## Summary
- add SEARCH_GMAIL_PATTERN to detect "search Gmail for" commands
- lower ML classification threshold
- update classifier to check the new pattern first
- expand unit tests with Gmail search commands

## Testing
- `pytest -q` *(fails: ANTHROPIC_API_KEY environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_b_683ff36cafe88326a8361299393bc9e6