### PR TITLE
Update search arguments and tests

### DIFF
--- a/gmail_chatbot/app/core.py
+++ b/gmail_chatbot/app/core.py
@@ -654,8 +654,8 @@ class GmailChatbotApp:
                     f"[{request_id}] user-initiated search_emails using: {gmail_search_string}"
                 )
                 emails, search_response_text = self.gmail_client.search_emails(
-                    search_query_override=query_text,  # Use the specific query from the menu
-                    user_query=original_user_message,  # Original context for Claude if needed by search_emails
+                    query=query_text,  # Use the specific query from the menu
+                    original_user_query=original_user_message,
                     system_message=self.system_message,
                     request_id=request_id,
                 )
@@ -1213,8 +1213,8 @@ class GmailChatbotApp:
                     )
                     emails, search_results_text = (
                         self.gmail_client.search_emails(
-                            search_query_override=gmail_search_string,
-                            user_query=original_user_message,
+                            query=gmail_search_string,
+                            original_user_query=original_user_message,
                             system_message=self.system_message,
                             request_id=request_id,
                         )
@@ -1610,8 +1610,8 @@ class GmailChatbotApp:
                         )
                         emails, search_results_text = (
                             self.gmail_client.search_emails(
-                                search_query_override=gmail_search_string,
-                                user_query=original_user_message,
+                                query=gmail_search_string,
+                                original_user_query=original_user_message,
                                 system_message=self.system_message,
                                 request_id=request_id,
                             )

--- a/tests/test_app_logic.py
+++ b/tests/test_app_logic.py
@@ -354,8 +354,8 @@ def test_email_search_confirmation_yes():
     original_user_message = app.pending_email_context["original_message"]
     acknowledgement = "👍 Starting the search now..."
     found_emails, search_results_text = app.gmail_client.search_emails(
-        search_query_override=gmail_search_string,
-        user_query=original_user_message,
+        query=gmail_search_string,
+        original_user_query=original_user_message,
         system_message=app.system_message,
         request_id="req2",
     )
@@ -374,8 +374,8 @@ def test_email_search_confirmation_yes():
 
     # Assertions matching expected flow
     app.gmail_client.search_emails.assert_called_once_with(
-        search_query_override="from:boss subject:urgent",
-        user_query="Find urgent emails from my boss",
+        query="from:boss subject:urgent",
+        original_user_query="Find urgent emails from my boss",
         system_message="sys",
         request_id=ANY,
     )


### PR DESCRIPTION
## Summary
- rename `search_query_override` parameter to `query`
- rename `user_query` argument to `original_user_query` for Gmail search
- adjust memory handler to use new argument names and limit results
- update tests for renamed arguments

## Testing
- `pytest -q` *(fails: ANTHROPIC_API_KEY environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_b_683ff600ac0c8326a5d45a7b3db86e19