### PR TITLE
Fix type alias naming

### DIFF
--- a/gmail_chatbot/agentic_executor.py
+++ b/gmail_chatbot/agentic_executor.py
@@ -5,7 +5,7 @@ from typing import Dict, Any, Optional
 from gmail_chatbot.memory_writers import store_professional_context
 
 # Define a type for the result of execute_step for clarity
-ExecuteStepResult = Dict[str, Any]
+execute_step_result = Dict[str, Any]
 
 # Module level logger
 logger = logging.getLogger(__name__)
@@ -140,7 +140,7 @@ ACTION_HANDLERS = {
     # Add more real action handlers here
 }
 
-def execute_step(step_details: Dict[str, Any], agentic_state: Dict[str, Any]) -> ExecuteStepResult:
+def execute_step(step_details: Dict[str, Any], agentic_state: Dict[str, Any]) -> execute_step_result:
     # --- Original code reinstated (with one toast modification) ---
     action_type = step_details.get("action_type")
     parameters = step_details.get("parameters", {})

--- a/gmail_chatbot/agentic_planner.py
+++ b/gmail_chatbot/agentic_planner.py
@@ -2,14 +2,14 @@
 from typing import List, Dict, Any, Optional
 
 # Define type aliases for clarity
-PlanStep = Dict[str, Any]
-Plan = List[PlanStep]
+plan_step = Dict[str, Any]
+plan = List[plan_step]
 
 # --- Predefined Plan Structures/Templates ---
 # These could be expanded significantly
 # Each function would generate a specific sequence of steps
 
-def _generate_search_summarize_log_plan(search_query: str, log_target: str = "default_notebook") -> Plan:
+def _generate_search_summarize_log_plan(search_query: str, log_target: str = "default_notebook") -> plan:
     return [
         {
             "step_id": "search_inbox_initial",
@@ -42,7 +42,7 @@ def _generate_search_summarize_log_plan(search_query: str, log_target: str = "de
     ]
 
 # --- Main Planner Function ---
-def generate_plan(user_query: str, current_session_state: dict) -> Optional[Plan]:
+def generate_plan(user_query: str, current_session_state: dict) -> Optional[plan]:
     """
     Generates a multi-step plan based on the user's query using heuristics.
     """


### PR DESCRIPTION
## Summary
- use snake_case for type aliases in `agentic_planner.py`
- use snake_case for type alias in `agentic_executor.py`

## Testing
- `ruff check gmail_chatbot/agentic_planner.py gmail_chatbot/agentic_executor.py --select N806,N815,N818`
- `pytest -q` *(fails: ANTHROPIC_API_KEY environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_b_683ff68c3f48832698412e24d452c4f3