### PR TITLE
Handle today's email query

### DIFF
--- a/gmail_chatbot/query_classifier.py
+++ b/gmail_chatbot/query_classifier.py
@@ -106,6 +106,9 @@ INFO_ON_PATTERN = re.compile(
 SEARCH_GMAIL_PATTERN = re.compile(
     r"\bsearch\s+gmail\s+for\s+(?P<query>.+)", re.IGNORECASE
 )
+TODAYS_EMAIL_PATTERN = re.compile(
+    r"\b(today'?s|todays)\s+email\b", re.IGNORECASE
+)
 
 def classify_query_type_regex(query: str) -> Tuple[QueryType, float, Dict[str, float]]:
     """Classify user query using regex pattern matching.
@@ -121,6 +124,10 @@ def classify_query_type_regex(query: str) -> Tuple[QueryType, float, Dict[str, f
     # Direct Gmail search command
     if SEARCH_GMAIL_PATTERN.search(query):
         return "email_search", 0.95, {"email_search": 0.95}
+
+    # Explicit request for today's email
+    if TODAYS_EMAIL_PATTERN.search(query):
+        return "email_search", 0.9, {"email_search": 0.9}
 
     # First check if the query matches any of our compiled direct lookup patterns
     if (
@@ -218,7 +225,7 @@ def classify_query_type_regex(query: str) -> Tuple[QueryType, float, Dict[str, f
     category, confidence = top_category
 
     # Boost or override to email_search for low scoring matches
-    if scores.get("email_search", 0) > 0.05:
+    if scores.get("email_search", 0) >= 0.03:
         if category != "email_search":
             logging.info("[REGEX] Overriding to email_search...")
         category = "email_search"

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -25,6 +25,7 @@ from gmail_chatbot.query_classifier import classify_query_type
         ("Can you check todays email?", "email_search"),
         ("search Gmail for from:bryce@example.com", "email_search"),
         ("check today's email", "email_search"),
+        ("tell me about todays email?", "email_search"),
         
         # Guard-rail heuristic should catch these
         ("Did I get any emails today?", "email_search"),


### PR DESCRIPTION
## Summary
- detect explicit requests for today's email before normalization
- allow single exact matches to trigger email search
- validate query classifier with new unit test

## Testing
- `pytest -q` *(fails: Email search flow and other modules)*

------
https://chatgpt.com/codex/tasks/task_b_683ff71db36c83269f6e8c76b3081131