### PR TITLE
Prevent duplicate enrichment threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ The main application `chat_app_st.py` demonstrates Streamlit chat widgets such a
 
 Short-term conversation state lives in `st.session_state`; for long-term or multi-user deployments, store history in external persistence (e.g., an EFS volume or database). When running at scale, containerize the app and place it behind a load balancer, applying caching and rate limiting to avoid hitting API quotas.
 
+The autonomous memory enrichment thread is also controlled via `st.session_state`. A flag named `autonomous_thread_started` prevents the enrichment thread from launching more than once per session.
+
 Agentic features use structured prompt templates and few-shot tool examples, allowing the chatbot to reason about tasks and self-correct when necessary.
 
 ## Using TASK_CHAIN


### PR DESCRIPTION
## Summary
- track whether the enrichment thread started in `GmailChatbotApp`
- only launch memory enrichment once per session
- document the new `autonomous_thread_started` flag

## Testing
- `ruff check gmail_chatbot/app/core.py` *(fails: F401, E402, F841, F821)*
- `pytest -q` *(fails: missing environment variables and other errors)*

------
https://chatgpt.com/codex/tasks/task_b_683ffa764c6c83269a0cd4b3e8ebf20c