### PR TITLE
Implement plan fallback

### DIFF
--- a/chat_app_st.py
+++ b/chat_app_st.py
@@ -408,7 +408,12 @@ if prompt := st.chat_input("Ask me about your inbox:"):
         if not st.session_state.get("agentic_plan"):
             with st.spinner("Bot is thinking..."):
                 plan = generate_plan(prompt, st.session_state)
-            if plan:
+            if plan is None:
+                assistant_reply = st.session_state.bot.process_message(prompt)
+                with st.chat_message("assistant"):
+                    st.markdown(assistant_reply)
+                st.session_state.bot.chat_history.append({"role": "assistant", "content": assistant_reply})
+            else:
                 st.session_state.agentic_plan = plan
                 st.session_state.agentic_state = default_agentic_state_values.copy()
                 plan_str = json.dumps(plan, indent=2)

--- a/tests/test_agentic_fallback.py
+++ b/tests/test_agentic_fallback.py
@@ -1,0 +1,87 @@
+import sys
+import types
+import contextlib
+from unittest.mock import MagicMock, patch
+import os
+import importlib
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+
+class SessionState(dict):
+    def __getattr__(self, item):
+        return self.get(item)
+
+    def __setattr__(self, key, value):
+        self[key] = value
+
+
+def _create_streamlit_stub(prompt: str) -> types.ModuleType:
+    st = types.ModuleType("streamlit")
+    st.session_state = SessionState()
+    st.chat_input = lambda *a, **k: prompt
+    st.chat_message = contextlib.nullcontext
+    st.set_page_config = lambda *a, **k: None
+    st.title = lambda *a, **k: None
+    st.progress = lambda *a, **k: types.SimpleNamespace(
+        progress=lambda *a2, **k2: None
+    )
+    st.markdown = lambda *a, **k: None
+    st.info = lambda *a, **k: None
+    st.error = lambda *a, **k: None
+    st.success = lambda *a, **k: None
+    st.warning = lambda *a, **k: None
+    st.balloons = lambda *a, **k: None
+    st.stop = lambda *a, **k: None
+    st.expander = lambda *a, **k: contextlib.nullcontext()
+
+    @contextlib.contextmanager
+    def spinner(*a, **k):
+        yield
+
+    st.spinner = spinner
+    st.sidebar = types.SimpleNamespace(
+        header=lambda *a, **k: None,
+        toggle=lambda *a, **k: None,
+        subheader=lambda *a, **k: None,
+        number_input=lambda *a, **k: None,
+        title=lambda *a, **k: None,
+        checkbox=lambda *a, **k: False,
+        file_uploader=lambda *a, **k: None,
+        success=lambda *a, **k: None,
+        warning=lambda *a, **k: None,
+        info=lambda *a, **k: None,
+        write=lambda *a, **k: None,
+        markdown=lambda *a, **k: None,
+        caption=lambda *a, **k: None,
+        expander=lambda *a, **k: contextlib.nullcontext(),
+    )
+    st.json = lambda *a, **k: None
+    return st
+
+
+def test_agentic_plan_fallback(monkeypatch):
+    st_stub = _create_streamlit_stub("hi")
+    sys.modules["streamlit"] = st_stub
+
+    st_stub.session_state.agentic_mode_enabled = True
+    st_stub.session_state.agentic_plan = None
+    st_stub.session_state.bot_initialized_successfully = True
+
+    dummy_bot = types.SimpleNamespace(
+        chat_history=[],
+        process_message=MagicMock(return_value="assistant reply"),
+    )
+    st_stub.session_state.bot = dummy_bot
+
+    with patch("gmail_chatbot.agentic_planner.generate_plan", return_value=None):
+        import chat_app_st
+
+    assert dummy_bot.process_message.called
+    assert dummy_bot.chat_history == [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "assistant reply"},
+    ]
+


### PR DESCRIPTION
## Summary
- handle plan generation failure in `chat_app_st.py`
- test that fallback calls `process_message` when no plan

## Testing
- `pytest tests/test_agentic_fallback.py -q`
- `pytest -q` *(fails: Missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_683ffa6ffdac8326acc226c2c227e436