### PR TITLE
Implement structured action item retrieval

### DIFF
--- a/gmail_chatbot/memory_handler.py
+++ b/gmail_chatbot/memory_handler.py
@@ -429,6 +429,27 @@ class MemoryActionsHandler:
                 )
         return "\n".join(response_parts)
 
+    def get_action_items_structured(
+        self, request_id: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        """Return action items that require attention.
+
+        Parameters
+        ----------
+        request_id:
+            Optional identifier used for logging.
+
+        Returns
+        -------
+        List[Dict[str, Any]]
+            Action items as provided by the memory store.
+        """
+        if request_id:
+            logger.info(f"[{request_id}] Retrieving structured action items.")
+        else:
+            logger.info("Retrieving structured action items.")
+        return self.memory_store.get_action_items()
+
     def manage_preferences(self, message: str, request_id: str) -> str:
         """Handle queries about user preferences.
 

--- a/tests/test_app_logic.py
+++ b/tests/test_app_logic.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest.mock import MagicMock, patch, ANY
+from gmail_chatbot.memory_handler import MemoryActionsHandler
 import sys
 import os
 
@@ -441,3 +442,26 @@ def test_handle_confirmation_ambiguous():
     assert "did you want me to proceed" in result.lower()
     assert app.pending_email_context["type"] == "gmail_query_confirmation"
     assert app.chat_history[-1]["content"] == result
+
+
+def test_get_action_items_structured():
+    """Ensure structured action items are returned as a list of dicts."""
+    memory_store = MagicMock()
+    sample_items = [
+        {"subject": "Task", "client": "ACME", "date": "2024-01-01"}
+    ]
+    memory_store.get_action_items.return_value = sample_items
+
+    handler = MemoryActionsHandler(
+        memory_store,
+        MagicMock(),
+        MagicMock(),
+        "sys",
+        MagicMock(),
+    )
+
+    result = handler.get_action_items_structured(request_id="req")
+
+    assert isinstance(result, list)
+    assert result == sample_items
+    memory_store.get_action_items.assert_called_once()


### PR DESCRIPTION
## Summary
- add `get_action_items_structured` to `MemoryActionsHandler`
- test that structured action items are returned

## Testing
- `pytest -q` *(fails: ANTHROPIC_API_KEY missing and other errors)*

------
https://chatgpt.com/codex/tasks/task_b_6840000d9a088326830e161a54a1a50e