### PR TITLE
Improve triage logic with history check

### DIFF
--- a/gmail_chatbot/app/core.py
+++ b/gmail_chatbot/app/core.py
@@ -564,6 +564,13 @@ class GmailChatbotApp:
         """Returns the stored error message from vector search initialization, if any."""
         return self.vector_search_error_message
 
+    def get_last_assistant_reply(self) -> Optional[str]:
+        """Return the most recent assistant message from the chat history."""
+        for entry in reversed(self.chat_history):
+            if entry.get("role") == "assistant":
+                return entry.get("content")
+        return None
+
     def _is_simple_inbox_query(self, message_lower: str) -> bool:
         """Checks if a query is a simple request for inbox contents, suitable for a menu."""
         generic_inbox_phrases = [

--- a/gmail_chatbot/memory_handler.py
+++ b/gmail_chatbot/memory_handler.py
@@ -99,6 +99,16 @@ class MemoryActionsHandler:
                 logger.error(f"[{request_id}] Error storing email {email_data.get('id')}: {e}")
         logger.info(f"[{request_id}] Finished storing emails.")
 
+    def find_related_emails(
+        self, query: str, limit: int = 5, request_id: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        """Delegate email search to the memory store."""
+        if request_id:
+            logger.info(
+                f"[{request_id}] Searching memory for emails related to: {query}"
+            )
+        return self.memory_store.find_related_emails(query, limit=limit)
+
     def handle_user_memory_query(self, message: str, request_id: str) -> Optional[str]:
         """Handle queries about stored memory information by dispatching to specific handlers.
 
@@ -428,6 +438,11 @@ class MemoryActionsHandler:
                     f"- Subject: {item.get('subject', 'N/A')}, Action: {item.get('action_type', 'N/A')}, Date: {item.get('date')}"
                 )
         return "\n".join(response_parts)
+
+    def get_action_items_structured(self, request_id: str) -> List[Dict[str, Any]]:
+        """Return raw action items for programmatic use."""
+        logging.info(f"[{request_id}] Retrieving structured action items")
+        return self.memory_store.get_action_items()
 
     def manage_preferences(self, message: str, request_id: str) -> str:
         """Handle queries about user preferences.


### PR DESCRIPTION
## Summary
- add `get_last_assistant_reply` helper to `GmailChatbotApp`
- add `_recent_triage_provided` check in triage handler and skip redundant Gmail searches
- expose structured action items and vector search helper methods in `MemoryActionsHandler`
- test repeated triage queries avoid repeated searches

## Testing
- `pytest -q` *(fails: ANTHROPIC_API_KEY environment variable is required)*

------
https://chatgpt.com/codex/tasks/task_b_6840003311ac83269fc89d4afcb1c7a4