### PR TITLE
Fix imports and clean unused imports

### DIFF
--- a/chat_app_st.py
+++ b/chat_app_st.py
@@ -14,6 +14,7 @@ from gmail_chatbot.agentic_executor import (
     summarize_and_log_agentic_results,  # Added for agentic execution
     handle_step_limit_reached,
 )
+from gmail_chatbot.email_config import CLAUDE_API_KEY_ENV, load_env
 
 # Module-level logger
 logger = logging.getLogger(__name__)
@@ -39,7 +40,6 @@ sys.excepthook = log_exception_to_file
 st.set_page_config(page_title="Gmail Chatbot", layout="wide")
 
 # from email_main import GmailChatbotApp # MOVED
-from gmail_chatbot.email_config import CLAUDE_API_KEY_ENV, load_env
 
 st.title("✉️ Gmail Claude Chatbot Assistant")
 
@@ -284,9 +284,12 @@ def initialize_chatbot() -> bool:
                     st.session_state["initialization_steps"].append(str("✓ Vector search loaded and available."))
                 else:
                     error_detail = "Vector search component reported as unavailable."
-                    if hasattr(st.session_state.bot, 'get_vector_search_error_message') and callable(st.session_state.bot.get_vector_search_error_message):
+                    if hasattr(st.session_state.bot, 'get_vector_search_error_message') and callable(
+                        st.session_state.bot.get_vector_search_error_message
+                    ):
                         msg = st.session_state.bot.get_vector_search_error_message()
-                        if msg: error_detail = str(msg) # Ensure string
+                        if msg:
+                            error_detail = str(msg)  # Ensure string
                     st.session_state["initialization_steps"].append(str(f"✗ Vector search failed: {error_detail}"))
                     # Vector search failure is non-critical for degraded mode.
                     # Store warning for UI display.

--- a/gmail_chatbot/app/__init__.py
+++ b/gmail_chatbot/app/__init__.py
@@ -1,1 +1,8 @@
 from .core import GmailChatbotApp, restore_streams, wait_for_threads, vector_memory
+
+__all__ = [
+    "GmailChatbotApp",
+    "restore_streams",
+    "wait_for_threads",
+    "vector_memory",
+]

--- a/gmail_chatbot/email_gmail_api.py
+++ b/gmail_chatbot/email_gmail_api.py
@@ -18,7 +18,7 @@ from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
 from gmail_chatbot.email_config import GMAIL_SCOPES, GMAIL_CLIENT_SECRET_FILE, GMAIL_TOKEN_FILE, \
-    DATA_DIR, LOGS_DIR, MAX_EMAILS_PER_SEARCH, MAX_EMAIL_BODY_CHARS
+    DATA_DIR, MAX_EMAILS_PER_SEARCH, MAX_EMAIL_BODY_CHARS
 from gmail_chatbot.email_claude_api import ClaudeAPIClient
 from gmail_chatbot.api_logging import log_gmail_request, log_gmail_response
 

--- a/gmail_chatbot/email_main.py
+++ b/gmail_chatbot/email_main.py
@@ -1,6 +1,5 @@
 """Backward compatibility wrapper for GmailChatbotApp."""
 
-import logging
 
 from gmail_chatbot.app.core import (
     GmailChatbotApp,

--- a/gmail_chatbot/email_memory_vector.py
+++ b/gmail_chatbot/email_memory_vector.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from gmail_chatbot.email_memory import EmailMemoryStore
 
 # Import the vector database
-from gmail_chatbot.email_vector_db import vector_db, VECTOR_LIBS_AVAILABLE
+from gmail_chatbot.email_vector_db import vector_db
 
 # Set up logging
 logger = logging.getLogger(__name__)

--- a/gmail_chatbot/email_vector_db.py
+++ b/gmail_chatbot/email_vector_db.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import sys
 
 try:
     _ = 1  # Dummy operation to ensure try block has content
@@ -103,8 +102,6 @@ except ImportError:
 
 # Try to import vector libraries with proper fallbacks
 try:
-    import faiss
-    import numpy as np
     from langchain_community.vectorstores import FAISS
 
     # Force FAISS to CPU-only mode as per user request / configuration

--- a/gmail_chatbot/gui/__init__.py
+++ b/gmail_chatbot/gui/__init__.py
@@ -1,1 +1,7 @@
 from .core import EmailChatbotGUI, GUI_AVAILABLE, can_initialize_gui
+
+__all__ = [
+    "EmailChatbotGUI",
+    "GUI_AVAILABLE",
+    "can_initialize_gui",
+]

--- a/tests/test_email_gmail_api.py
+++ b/tests/test_email_gmail_api.py
@@ -1,20 +1,19 @@
 import unittest
-from unittest.mock import patch, MagicMock, mock_open, ANY  # Restore ANY
+from unittest.mock import patch, MagicMock  # Restore ANY
 import os  # Restore os
 import sys  # Restore sys
 import ssl  # For ssl.SSLError
 import logging  # For disabling/enabling logger in tests
 import json  # For creating mock client_secret file
-import pickle  # For mocking credential loading/saving
 from pathlib import Path  # For type checking in mocks
 import types
 
 try:
     from google.oauth2.credentials import Credentials  # type: ignore
-    import google.auth.exceptions  # type: ignore
-    import google.auth.transport.requests  # type: ignore
-    import google_auth_oauthlib.flow  # type: ignore
-    import googleapiclient.discovery  # type: ignore
+    import google.auth.exceptions as _  # type: ignore # noqa: F401
+    import google.auth.transport.requests as _  # type: ignore # noqa: F401
+    import google_auth_oauthlib.flow as _  # type: ignore # noqa: F401
+    import googleapiclient.discovery as _  # type: ignore # noqa: F401
 except ModuleNotFoundError:
     # Create minimal stub modules so that patch() calls work without the real packages
     class Credentials:
@@ -155,9 +154,6 @@ class TestGmailAPIClientSSLErrors(unittest.TestCase):
             # to ensure we are using the potentially reloaded module where 'build' is patched.
             from gmail_chatbot.email_gmail_api import (
                 GmailAPIClient,
-                DATA_DIR,
-                GMAIL_TOKEN_FILE,
-                GMAIL_CLIENT_SECRET_FILE,
             )
 
             # Attempt to instantiate the client. If DATA_DIR.mkdir was the issue at import,
@@ -365,7 +361,8 @@ class TestGmailAPIClientSSLErrors(unittest.TestCase):
 
 class TestLastGmailErrorFlag(unittest.TestCase):
     def setUp(self):
-        import sys, types
+        import sys
+        import types
         if 'streamlit' not in sys.modules:
             st_stub = types.ModuleType('streamlit')
             st_stub.session_state = {}


### PR DESCRIPTION
## Summary
- rearrange imports so Streamlit config comes after them
- declare exported symbols in package `__init__` modules
- drop unused imports in Gmail modules and tests
- remove unused FAISS imports

## Testing
- `ruff check . | head -n 5`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6840008ca93c8326adc0f93c697f7e50