### PR TITLE
Improve triage handler history awareness

### DIFF
--- a/gmail_chatbot/app/core.py
+++ b/gmail_chatbot/app/core.py
@@ -564,6 +564,13 @@ class GmailChatbotApp:
         """Returns the stored error message from vector search initialization, if any."""
         return self.vector_search_error_message
 
+    def get_last_assistant_reply(self) -> Optional[str]:
+        """Return the most recent assistant message from ``chat_history``."""
+        for message in reversed(self.chat_history):
+            if message.get("role") == "assistant":
+                return message.get("content")
+        return None
+
     def _is_simple_inbox_query(self, message_lower: str) -> bool:
         """Checks if a query is a simple request for inbox contents, suitable for a menu."""
         generic_inbox_phrases = [
@@ -1119,11 +1126,7 @@ class GmailChatbotApp:
             return response
 
         if len(self.chat_history) >= 2:
-            last_assistant_msg = None
-            for i in range(len(self.chat_history) - 2, -1, -1):
-                if self.chat_history[i]["role"] == "assistant":
-                    last_assistant_msg = self.chat_history[i]["content"]
-                    break
+            last_assistant_msg = self.get_last_assistant_reply()
             if (
                 last_assistant_msg
                 and "TASK_CHAIN:" in last_assistant_msg

--- a/gmail_chatbot/handlers/triage.py
+++ b/gmail_chatbot/handlers/triage.py
@@ -84,10 +84,18 @@ def handle_triage_query(
             )
             response = postprocess_claude_response(response)
         else:
-            response = (
-                "I checked for urgent items and also performed a quick search based "
-                "on your message, but didn't find anything specific that needs immediate attention."
-            )
+            last_reply = app.get_last_assistant_reply() or ""
+            search_prompt = "Should I check your inbox"
+            if search_prompt.lower() in last_reply.lower():
+                response = (
+                    "I already looked for urgent items recently and didn't find anything new."
+                )
+            else:
+                response = (
+                    "I checked for urgent items and also performed a quick search based "
+                    "on your message, but didn't find anything specific that needs immediate attention. "
+                    "Should I check your inbox directly for more recent updates?"
+                )
     else:
         response = (
             "I checked for urgent items, but there's nothing specific in the action list right now, "

--- a/tests/test_app_logic.py
+++ b/tests/test_app_logic.py
@@ -199,6 +199,40 @@ def test_process_message_triage(mock_pref_detector, mock_classify, mock_vec_mem,
 
 @pytest.mark.skipif(GmailChatbotApp is None, reason="GmailChatbotApp could not be imported from email_main.py")
 @patch('gmail_chatbot.email_main.ClaudeAPIClient')
+@patch('gmail_chatbot.email_main.vector_memory')
+@patch('gmail_chatbot.email_main.classify_query_type')
+@patch('gmail_chatbot.email_main.preference_detector')
+def test_triage_no_duplicate_gmail_prompt(mock_pref_detector, mock_classify, mock_vec_mem, mock_claude, mock_dependencies):
+    """Triage shouldn't keep asking to search Gmail if it just asked."""
+    mock_claude_client_instance = mock_claude.return_value
+
+    mock_classify.return_value = (
+        "triage",
+        0.9,
+        {"trigger_phrase": "triage"},
+        "Classified as triage request."
+    )
+    mock_pref_detector.process_message.return_value = (False, None)
+    mock_vec_mem.find_relevant_preferences.return_value = []
+    mock_vec_mem.vector_search_available = True
+    mock_vec_mem.find_related_emails.return_value = []
+
+    mock_claude_client_instance.evaluate_vector_match.return_value = ""
+
+    app = GmailChatbotApp()
+    app.claude_client = mock_claude_client_instance
+    app.memory_store = mock_vec_mem
+
+    first = app.process_message("Triage")
+    assert "Should I check your inbox" in first
+
+    mock_vec_mem.find_related_emails.reset_mock()
+    second = app.process_message("Triage")
+    assert "Should I check your inbox" not in second
+
+
+@pytest.mark.skipif(GmailChatbotApp is None, reason="GmailChatbotApp could not be imported from email_main.py")
+@patch('gmail_chatbot.email_main.ClaudeAPIClient')
 @patch('gmail_chatbot.email_main.classify_query_type')
 @patch('gmail_chatbot.email_main.preference_detector')
 @patch('gmail_chatbot.email_main.vector_memory')


### PR DESCRIPTION
## Summary
- add helper `get_last_assistant_reply` on `GmailChatbotApp`
- use helper in confirmation logic and triage handler
- avoid repeating Gmail search prompt in triage flow
- add regression test for duplicate triage prompts

## Testing
- `pytest -q` *(fails: embedding model and email search tests fail in container)*

------
https://chatgpt.com/codex/tasks/task_b_684001ca237c83269af50200c89a4557