### PR TITLE
Add basic note-taking support

### DIFF
--- a/gmail_chatbot/app/core.py
+++ b/gmail_chatbot/app/core.py
@@ -1429,6 +1429,22 @@ class GmailChatbotApp:
         if confirm_response:
             return proactive_response_part + confirm_response
 
+        note_cmds = ["create note", "create notes", "remember this", "note this"]
+        for cmd in note_cmds:
+            if message_lower.startswith(cmd):
+                text = message[len(cmd):].strip()
+                if not text:
+                    text = self.get_last_assistant_reply() or ""
+                if not text:
+                    response = "I couldn't find text to save as a note."
+                else:
+                    if self.enhanced_memory_store.save_note_from_text(text):
+                        response = "\U0001F4D3 Saved that note."  # notebook emoji
+                    else:
+                        response = "Couldn't save the note due to an error."
+                self.chat_history.append({"role": "assistant", "content": response})
+                return proactive_response_part + response
+
         # Check for explicit preference memory instructions
         memory_triggers = [
             "remember that",

--- a/gmail_chatbot/enhanced_memory.py
+++ b/gmail_chatbot/enhanced_memory.py
@@ -429,6 +429,34 @@ class EnhancedMemoryStore:
             except Exception as ve:
                 logger.warning(f"Failed to add preference to vector db: {ve}")
                 # Continue without vector DB - it's not critical
+
+    def save_note_from_text(self, content: str,
+                            tags: Optional[List[str]] = None) -> bool:
+        """Save a plain text note in ``memory_entries`` via ``add_memory_entry``.
+
+        Parameters
+        ----------
+        content:
+            The note text to store.
+        tags:
+            Optional list of tags for the note.
+
+        Returns
+        -------
+        bool
+            ``True`` if the note was saved successfully, ``False`` otherwise.
+        """
+        logger.info("Saving note from text: %s", content[:50])
+
+        entry = MemoryEntry(
+            kind=MemoryKind.NOTE,
+            content=content,
+            source=MemorySource.USER,
+            tags=tags or [],
+        ).to_dict()
+
+        # ``add_memory_entry`` already handles exceptions and returns ``bool``
+        return self.add_memory_entry(entry)
     
     def add_interaction_memory(self, content: str, tags: Optional[List[str]] = None, 
                                 meta: Optional[Dict[str, Any]] = None) -> None:


### PR DESCRIPTION
## Summary
- add `save_note_from_text` in `EnhancedMemoryStore`
- detect note commands in `GmailChatbotApp`
- list notes with new `list_saved_notes` in `MemoryActionsHandler`
- test note creation and listing

## Testing
- `pytest tests/test_enhanced_memory.py -q`
- `pytest -q` *(fails: Can't pickle <class 'unittest.mock.MagicMock'> ...)*

------
https://chatgpt.com/codex/tasks/task_b_684020605f5c8326836afc3d8e3f7cf7