### PR TITLE
Improve preference handling

### DIFF
--- a/gmail_chatbot/app/core.py
+++ b/gmail_chatbot/app/core.py
@@ -1429,20 +1429,29 @@ class GmailChatbotApp:
         if confirm_response:
             return proactive_response_part + confirm_response
 
-        note_cmds = ["create note", "create notes", "remember this", "note this"]
+        note_cmds = [
+            "create note",
+            "create notes",
+            "remember this",
+            "note this",
+        ]
         for cmd in note_cmds:
             if message_lower.startswith(cmd):
-                text = message[len(cmd):].strip()
+                text = message[len(cmd) :].strip()
                 if not text:
                     text = self.get_last_assistant_reply() or ""
                 if not text:
                     response = "I couldn't find text to save as a note."
                 else:
                     if self.enhanced_memory_store.save_note_from_text(text):
-                        response = "\U0001F4D3 Saved that note."  # notebook emoji
+                        response = (
+                            "\U0001f4d3 Saved that note."  # notebook emoji
+                        )
                     else:
                         response = "Couldn't save the note due to an error."
-                self.chat_history.append({"role": "assistant", "content": response})
+                self.chat_history.append(
+                    {"role": "assistant", "content": response}
+                )
                 return proactive_response_part + response
 
         # Check for explicit preference memory instructions
@@ -1905,8 +1914,8 @@ class GmailChatbotApp:
                 f"[{request_id}] Falling back to general Claude chat for message: {message[:50]}..."
             )
 
-            relevant_preferences = (
-                self.memory_actions_handler.find_relevant_preferences(message)
+            relevant_preferences = self.memory_store.find_relevant_preferences(
+                message
             )
             preference_context = ""
             if relevant_preferences:

--- a/tests/test_preference_detector.py
+++ b/tests/test_preference_detector.py
@@ -1,0 +1,22 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from gmail_chatbot.preference_detector import PreferenceDetector
+
+
+@patch("gmail_chatbot.preference_detector.classify_query_type")
+def test_preference_detector_stores_preference(mock_classify):
+    """PreferenceDetector should store preferences via EnhancedMemoryStore."""
+    mock_classify.return_value = ("preference_update", 0.9, {})
+    memory_store = MagicMock()
+    detector = PreferenceDetector(memory_store)
+
+    detected, feedback = detector.process_message(
+        "ShowUp or showup.courses is my brand"
+    )
+
+    assert detected
+    memory_store.remember_user_preference.assert_called_once_with(
+        "ShowUp or showup.courses is my brand", label="general_preference"
+    )
+    assert "Noted" in feedback


### PR DESCRIPTION
## Summary
- inject notes from `find_relevant_preferences` into system prompt
- add tests for brand preference recall
- check that `PreferenceDetector` stores preferences

## Testing
- `pytest -q` *(fails: AttributeError: 'SessionState' object has no attribute 'autonomous_thread_s...)*

------
https://chatgpt.com/codex/tasks/task_b_6840224e5000832697929d91b5001b0f