### PR TITLE
Improve notebook logging guard

### DIFF
--- a/chat_app_st.py
+++ b/chat_app_st.py
@@ -155,6 +155,9 @@ def run_agentic_plan() -> None:
             progress_bar.progress((idx + 1) / len(plan))
             return
 
+        if execution_result.get("status") == "skipped":
+            st.info(execution_result.get("message", "Step skipped"))
+
         agentic_state["current_step_index"] = idx + 1
         st.session_state.agentic_state = agentic_state
         progress_bar.progress(agentic_state["current_step_index"] / len(plan))

--- a/gmail_chatbot/agentic_planner.py
+++ b/gmail_chatbot/agentic_planner.py
@@ -36,8 +36,13 @@ def _generate_search_summarize_log_plan(search_query: str, log_target: str = "de
             "step_id": "log_to_notebook",
             "description": f"Step 4: Log the summary to '{log_target}'.",
             "action_type": "log_to_notebook",
-            "parameters": {"input_data_key": "final_summary", "notebook_id": log_target, "section_title": f"Findings for '{search_query}'"},
-            "output_key": "logging_confirmation"
+            "parameters": {
+                "input_data_key": "final_summary",
+                "notebook_id": log_target,
+                "section_title": f"Findings for '{search_query}'",
+                "overwrite_if_exists": False,
+            },
+            "output_key": "logging_confirmation",
         }
     ]
 


### PR DESCRIPTION
## Summary
- check for existing professional context before storing
- allow overwriting or skipping of existing entry
- plan generator specifies no overwrite
- show info when step skipped
- cover log overwriting and skip conditions

## Testing
- `pytest tests/test_agentic_executor.py::TestAgenticExecutorFlow::test_log_to_notebook_skipped_if_duplicate -q`
- `pytest -q` *(fails: Can't pickle <class 'unittest.mock.MagicMock'> and other errors)*

------
https://chatgpt.com/codex/tasks/task_b_6840263f1bac8326a69555ee47f4b47b