### PR TITLE
Add notebook overview helper

### DIFF
--- a/chat_app_st.py
+++ b/chat_app_st.py
@@ -7,6 +7,7 @@ import traceback
 import io
 import time
 import json
+import uuid
 from pathlib import Path
 from gmail_chatbot.agentic_planner import generate_plan
 from gmail_chatbot.agentic_executor import (
@@ -447,6 +448,13 @@ if "batch_mode" not in st.session_state:
 st.session_state.batch_mode = st.sidebar.checkbox(
     "Batch Mode", value=st.session_state.batch_mode, key="batch_mode_checkbox"
 )
+
+if st.sidebar.button("Show Notebook Summary"):
+    if st.session_state.get("bot"):
+        summary = st.session_state.bot.get_notebook_overview(str(uuid.uuid4()))
+        st.sidebar.info(summary)
+    else:
+        st.sidebar.warning("Bot not initialized.")
 
 log_file = st.sidebar.file_uploader(
     "Upload log file for review", type="txt", key="log_uploader"

--- a/gmail_chatbot/app/core.py
+++ b/gmail_chatbot/app/core.py
@@ -601,6 +601,10 @@ class GmailChatbotApp:
                 break
         return False
 
+    def get_notebook_overview(self, request_id: str) -> str:
+        """Return a concise overview of the notebook contents."""
+        return self.memory_actions_handler.get_notebook_overview(request_id)
+
     def _is_simple_inbox_query(self, message_lower: str) -> bool:
         """Checks if a query is a simple request for inbox contents, suitable for a menu."""
         generic_inbox_phrases = [
@@ -914,6 +918,17 @@ class GmailChatbotApp:
             elif gmail_text:
                 response = f"{response}\n\n{gmail_text}"
 
+
+        # Append a brief notebook overview when no notebook results were found
+        if not search_results:
+            try:
+                overview = self.get_notebook_overview(request_id)
+                if overview:
+                    response = f"{response}\n\n{overview}"
+            except Exception as e:  # pragma: no cover - defensive
+                logging.error(
+                    f"[{request_id}] Failed to append notebook overview: {e}"
+                )
 
         # Log the notebook search (hit or miss) via MemoryActionsHandler
         self.memory_actions_handler.record_interaction_in_memory(

--- a/tests/test_task_chain_flow.py
+++ b/tests/test_task_chain_flow.py
@@ -43,6 +43,7 @@ if 'streamlit' not in sys.modules:
         number_input=lambda *a, **k: None,
         title=lambda *a, **k: None,
         checkbox=lambda *a, **k: False,
+        button=lambda *a, **k: None,
         file_uploader=lambda *a, **k: None,
         success=lambda *a, **k: None,
         warning=lambda *a, **k: None,
@@ -72,8 +73,8 @@ else:
         st_stub.sidebar = types.SimpleNamespace()
     sidebar = st_stub.sidebar
     for attr in ['header', 'toggle', 'subheader', 'number_input', 'title', 'checkbox',
-                 'file_uploader', 'success', 'warning', 'info', 'write', 'markdown',
-                 'caption', 'expander']:
+                 'button', 'file_uploader', 'success', 'warning', 'info', 'write',
+                 'markdown', 'caption', 'expander']:
         if not hasattr(sidebar, attr):
             setattr(sidebar, attr, (lambda *a, **k: None) if attr != 'expander' else (lambda *a, **k: contextlib.nullcontext()))
     for attr in ['toast', 'set_page_config', 'title', 'progress', 'info', 'error',


### PR DESCRIPTION
## Summary
- expose `get_notebook_overview` on `GmailChatbotApp`
- append notebook overview when notebook lookup finds nothing
- add button in Streamlit UI to show the notebook overview
- update Streamlit test stubs for the new sidebar button

## Testing
- `pytest -q` *(fails: AttributeError: 'Sidebar' object has no attribute 'button', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68402dac2e2483269f1af605387c4372