### PR TITLE
Update env example and README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 # Example environment configuration for Gmail Chatbot
 # Copy this file to .env and replace with your actual key
 ANTHROPIC_API_KEY=your_key_here
+CLAUDE_PREP_MODEL=claude-3-5-haiku-20250612

--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ A Claude-powered chatbot that interacts with your Gmail account. This tool allow
 
    ```env
    ANTHROPIC_API_KEY=your_key_here
+   CLAUDE_PREP_MODEL=claude-3-5-haiku-20250612
    ```
    The application automatically loads this `.env` file at startup via `gmail_chatbot.email_config.load_env()`.
+   `CLAUDE_PREP_MODEL` selects the Claude model used to prep email history.
    Configure all required environment variables here once.
 
 ### 2. Google Cloud Setup


### PR DESCRIPTION
## Summary
- add `CLAUDE_PREP_MODEL` variable to `.env.example`
- document `CLAUDE_PREP_MODEL` in README

## Testing
- `pytest -q` *(fails: AttributeError in sidebar button and multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_b_6840308a27a88326b272873ddf787569