### PR TITLE
Use prep model for reasoning steps

### DIFF
--- a/gmail_chatbot/agentic_executor.py
+++ b/gmail_chatbot/agentic_executor.py
@@ -51,7 +51,12 @@ def _execute_extract_entities(parameters: Dict[str, Any], agentic_state: Dict[st
         return {"status": "failure", "message": "Claude client not available"}
 
     try:
-        entities = claude_client.process_email_content(input_data, extraction_prompt, system_message)
+        entities = claude_client.process_email_content(
+            input_data,
+            extraction_prompt,
+            system_message,
+            model=claude_client.prep_model,
+        )
         return {"status": "success", "data": entities, "message": "Entities extracted"}
     except Exception as e:  # pragma: no cover - defensive
         return {"status": "failure", "message": f"Entity extraction failed: {e}"}
@@ -71,7 +76,12 @@ def _execute_summarize_text(parameters: Dict[str, Any], agentic_state: Dict[str,
 
     try:
         prompt = f"Please provide a concise summary of the following information:\n{input_data}"
-        summary = claude_client.chat(prompt, [], system_message)
+        summary = claude_client.chat(
+            prompt,
+            [],
+            system_message,
+            model=claude_client.prep_model,
+        )
         return {"status": "success", "data": summary, "message": "Text summarized"}
     except Exception as e:  # pragma: no cover - defensive
         return {"status": "failure", "message": f"Summarization failed: {e}"}

--- a/gmail_chatbot/app/core.py
+++ b/gmail_chatbot/app/core.py
@@ -988,6 +988,7 @@ class GmailChatbotApp:
                 user_query=reasoning_prompt,
                 system_message=modified_system_message,
                 request_id=f"{request_id}_reasoning",
+                model=self.claude_client.prep_model,
             )
             if vector_reasoning.startswith("VECTOR_SEARCH:"):
                 extracted_terms = vector_reasoning.replace(
@@ -1576,6 +1577,7 @@ class GmailChatbotApp:
                     f"Summarize this user preference into a single clear sentence for memory storage: {message}",
                     self.system_message,
                     request_id=request_id,
+                    model=self.claude_client.prep_model,
                 )
                 # Use original message as fallback if summary generation fails
                 content = (

--- a/gmail_chatbot/app/handlers/email_search.py
+++ b/gmail_chatbot/app/handlers/email_search.py
@@ -99,6 +99,7 @@ def handle_email_search_query(
             user_query=message,
             system_message=app.system_message,
             request_id=request_id,
+            model=app.claude_client.prep_model,
         )
 
         if query_suggestion_from_claude.startswith("ASK_USER:"):

--- a/gmail_chatbot/email_gmail_api.py
+++ b/gmail_chatbot/email_gmail_api.py
@@ -347,7 +347,10 @@ class GmailAPIClient:
             # Process email data through Claude if system_message is provided
             if system_message and self.claude:
                 claude_response = self.claude.process_email_content(
-                    email_data, original_user_query, system_message
+                    email_data,
+                    original_user_query,
+                    system_message,
+                    model=self.claude.prep_model,
                 )
                 return email_data, claude_response
             else:
@@ -417,10 +420,18 @@ class GmailAPIClient:
             
             # Process email data through Claude for user-friendly response
             if user_query:
-                response = self.claude.process_email_content(email_info, user_query, self.system_message)
+                response = self.claude.process_email_content(
+                    email_info,
+                    user_query,
+                    self.system_message,
+                    model=self.claude.prep_model,
+                )
             else:
                 response = self.claude.process_email_content(
-                    email_info, "Summarize this email and extract key information", self.system_message
+                    email_info,
+                    "Summarize this email and extract key information",
+                    self.system_message,
+                    model=self.claude.prep_model,
                 )
             
             return email_info, response


### PR DESCRIPTION
## Summary
- ensure reasoning queries use Claude prep model
- route entity extraction and summarization to prep model
- use prep model when summarizing user preferences
- use prep model for background email search queries

## Testing
- `pytest -q` *(fails: AttributeError & AssertionError)*

------
https://chatgpt.com/codex/tasks/task_b_684037bcdbd88326aa8d35ee7eb4c73a