### PR TITLE
Update tests for prep model usage

### DIFF
--- a/tests/test_claude_api_client.py
+++ b/tests/test_claude_api_client.py
@@ -1,0 +1,23 @@
+import os
+import types
+from unittest.mock import MagicMock
+
+from gmail_chatbot.email_claude_api import ClaudeAPIClient, CLAUDE_API_KEY_ENV
+
+
+def test_process_email_content_model_forwarded(monkeypatch):
+    os.environ[CLAUDE_API_KEY_ENV] = "test-key"
+    mock_response = MagicMock()
+    mock_response.content = [types.SimpleNamespace(text="ok")]
+    mock_response.usage = types.SimpleNamespace(input_tokens=1, output_tokens=1)
+    create_mock = MagicMock(return_value=mock_response)
+    mock_client = MagicMock()
+    mock_client.messages.create = create_mock
+    monkeypatch.setattr("anthropic.Anthropic", lambda api_key: mock_client, raising=False)
+
+    client = ClaudeAPIClient(model="dummy", prep_model="prep-model")
+    email_data = {"id": "1"}
+    client.process_email_content(email_data, "summary", "sys", model=client.prep_model)
+
+    create_mock.assert_called_once()
+    assert create_mock.call_args.kwargs["model"] == client.prep_model

--- a/tests/test_email_gmail_api.py
+++ b/tests/test_email_gmail_api.py
@@ -107,6 +107,7 @@ class TestGmailAPIClientSSLErrors(unittest.TestCase):
             json.dump(mock_secret_content, f)
 
         self.mock_claude_client = MagicMock()
+        self.mock_claude_client.prep_model = "prep-model"
         self.mock_system_message = "Test system message"
     
     def tearDown(self):


### PR DESCRIPTION
## Summary
- expect `prep_model` when Claude client is invoked
- verify that `process_email_content` forwards the model

## Testing
- `pytest tests/test_agentic_executor.py::TestAgenticExecutorFlow::test_search_extract_summarize_and_log tests/test_app_logic.py::test_process_message_general_chat tests/test_claude_api_client.py::test_process_email_content_model_forwarded -q`
- `pytest -q` *(fails: test suite reports missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68403a0a503c832698907e334760d31e