### PR TITLE
Document prep model usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@
 - Added Continue/Stop prompt when autonomous step limit is reached
 - INFO level logs for agentic step execution now written to
   `logs/gmail_chatbot/` for troubleshooting
+- `CLAUDE_PREP_MODEL` environment variable to configure a cheaper model for
+  preparatory steps.
+- `ClaudeAPIClient` methods accept an optional `model` argument and expose a
+  `prep_model` attribute for inexpensive preprocessing.
+- Internal summarization and query-parsing calls route to the prep model while
+  user-facing chat continues using the default model.
+- Unit tests updated to validate model selection logic.
 
 ### Changed
 


### PR DESCRIPTION
## Summary
- document CLAUDE_PREP_MODEL and model selection behaviour in CHANGELOG

## Testing
- `pytest -q` *(fails: 12 failed, 67 passed, 20 errors)*
- `pytest tests/test_email_search_flow.py::TestEmailSearchFlow::test_email_search_routing -vv`
- `pytest tests/test_notebook_guardrail.py::test_notebook_guardrail_entity_extraction -vv`


------
https://chatgpt.com/codex/tasks/task_b_68402be980e8832685b7a49070a0ba9b