### PR TITLE
Handle Anthropic model-not-found errors

### DIFF
--- a/gmail_chatbot/email_claude_api.py
+++ b/gmail_chatbot/email_claude_api.py
@@ -174,12 +174,23 @@ class ClaudeAPIClient:
             )  # <-- ADDED LOG LINE
 
             # Call Claude API
-            response = self.client.messages.create(
-                model=model_to_use,
-                max_tokens=CLAUDE_MAX_TOKENS,
-                system=system_message,
-                messages=[{"role": "user", "content": prompt}],
-            )
+            try:
+                response = self.client.messages.create(
+                    model=model_to_use,
+                    max_tokens=CLAUDE_MAX_TOKENS,
+                    system=system_message,
+                    messages=[{"role": "user", "content": prompt}],
+                )
+            except getattr(
+                anthropic, "errors", anthropic
+            ).NotFoundError as api_err:
+                logging.error(
+                    f"[{request_id}] Claude API model not found: {api_err}"
+                )
+                return "ERROR: The specified Claude model is invalid or inaccessible."
+            except getattr(anthropic, "APIError", Exception) as api_err:
+                logging.error(f"[{request_id}] Claude API error: {api_err}")
+                return "ERROR: The specified Claude model is invalid or inaccessible."
 
             # Extract the formatted query
             formatted_query = response.content[0].text.strip()
@@ -331,12 +342,21 @@ class ClaudeAPIClient:
             )
 
             # Call Claude API
-            response = self.client.messages.create(
-                model=model_to_use,
-                max_tokens=CLAUDE_MAX_TOKENS,
-                system=system_message,
-                messages=[{"role": "user", "content": prompt}],
-            )
+            try:
+                response = self.client.messages.create(
+                    model=model_to_use,
+                    max_tokens=CLAUDE_MAX_TOKENS,
+                    system=system_message,
+                    messages=[{"role": "user", "content": prompt}],
+                )
+            except getattr(
+                anthropic, "errors", anthropic
+            ).NotFoundError as api_err:
+                logging.error(f"Claude API model not found: {api_err}")
+                return "Error: The specified Claude model is invalid or inaccessible."
+            except getattr(anthropic, "APIError", Exception) as api_err:
+                logging.error(f"Claude API error: {api_err}")
+                return "Error: The specified Claude model is invalid or inaccessible."
 
             # Extract the processed content
             processed_content = response.content[0].text.strip()

--- a/tests/test_claude_api_client.py
+++ b/tests/test_claude_api_client.py
@@ -9,15 +9,69 @@ def test_process_email_content_model_forwarded(monkeypatch):
     os.environ[CLAUDE_API_KEY_ENV] = "test-key"
     mock_response = MagicMock()
     mock_response.content = [types.SimpleNamespace(text="ok")]
-    mock_response.usage = types.SimpleNamespace(input_tokens=1, output_tokens=1)
+    mock_response.usage = types.SimpleNamespace(
+        input_tokens=1, output_tokens=1
+    )
     create_mock = MagicMock(return_value=mock_response)
     mock_client = MagicMock()
     mock_client.messages.create = create_mock
-    monkeypatch.setattr("anthropic.Anthropic", lambda api_key: mock_client, raising=False)
+    monkeypatch.setattr(
+        "anthropic.Anthropic", lambda api_key: mock_client, raising=False
+    )
 
     client = ClaudeAPIClient(model="dummy", prep_model="prep-model")
     email_data = {"id": "1"}
-    client.process_email_content(email_data, "summary", "sys", model=client.prep_model)
+    client.process_email_content(
+        email_data, "summary", "sys", model=client.prep_model
+    )
 
     create_mock.assert_called_once()
     assert create_mock.call_args.kwargs["model"] == client.prep_model
+
+
+def test_process_query_model_not_found(monkeypatch):
+    os.environ[CLAUDE_API_KEY_ENV] = "test-key"
+
+    class NotFoundError(Exception):
+        pass
+
+    monkeypatch.setattr(
+        "anthropic.errors",
+        types.SimpleNamespace(NotFoundError=NotFoundError),
+        raising=False,
+    )
+    monkeypatch.setattr("anthropic.APIError", NotFoundError, raising=False)
+
+    mock_client = MagicMock()
+    mock_client.messages.create.side_effect = NotFoundError("bad model")
+    monkeypatch.setattr(
+        "anthropic.Anthropic", lambda api_key: mock_client, raising=False
+    )
+
+    client = ClaudeAPIClient(model="bad", prep_model="prep-model")
+    result = client.process_query("query", "sys")
+    assert "invalid or inaccessible" in result.lower()
+
+
+def test_process_email_content_model_not_found(monkeypatch):
+    os.environ[CLAUDE_API_KEY_ENV] = "test-key"
+
+    class NotFoundError(Exception):
+        pass
+
+    monkeypatch.setattr(
+        "anthropic.errors",
+        types.SimpleNamespace(NotFoundError=NotFoundError),
+        raising=False,
+    )
+    monkeypatch.setattr("anthropic.APIError", NotFoundError, raising=False)
+
+    mock_client = MagicMock()
+    mock_client.messages.create.side_effect = NotFoundError("bad model")
+    monkeypatch.setattr(
+        "anthropic.Anthropic", lambda api_key: mock_client, raising=False
+    )
+
+    client = ClaudeAPIClient(model="bad", prep_model="prep-model")
+    result = client.process_email_content({"id": "1"}, "sum", "sys")
+    assert "invalid or inaccessible" in result.lower()


### PR DESCRIPTION
## Summary
- catch `anthropic` errors when calling Claude API
- add unit tests for model-not-found handling

## Testing
- `pytest -k claude_api_client -q`
- `pytest -q` *(fails: SessionState object has no attribute 'autonomous_thread_* etc.)*

------
https://chatgpt.com/codex/tasks/task_b_6840518964508326ba10049bb8e5bbda