### PR TITLE
Implement placeholder action handler

### DIFF
--- a/gmail_chatbot/agentic_executor.py
+++ b/gmail_chatbot/agentic_executor.py
@@ -177,6 +177,16 @@ def _execute_placeholder_summarize(parameters: Dict[str, Any], agentic_state: Di
     return {"status": "success", "data": f"Simulated summary of {len(input_docs)} documents.", "message": "Placeholder summary complete."}
 
 
+def _execute_placeholder_action(parameters: Dict[str, Any], agentic_state: Dict[str, Any]) -> Dict[str, Any]:
+    """Log placeholder action and return skipped status."""
+    logger.info("Placeholder action encountered. Parameters=%s", parameters)
+    return {
+        "status": "skipped",
+        "message": "Placeholder action skipped.",
+        "updated_agentic_state": agentic_state,
+    }
+
+
 # --- Main Executor Function ---
 # Maps action_type to its handler function
 ACTION_HANDLERS = {
@@ -187,6 +197,7 @@ ACTION_HANDLERS = {
     "send_email": _execute_send_email,
     "placeholder_search_tool": _execute_placeholder_search, # Kept for existing test plan
     "placeholder_summarize_tool": _execute_placeholder_summarize, # Kept for existing test plan
+    "placeholder_action": _execute_placeholder_action,
     # Add more real action handlers here
 }
 
@@ -261,6 +272,8 @@ def execute_step(step_details: Dict[str, Any], agentic_state: Dict[str, Any]) ->
             status,
             state_summary,
         )
+        if status == "skipped":
+            logger.info("Step %s skipped: %s", step_id, message)
         
         print(f"DEBUG EXECUTOR: Step '{step_id} - {step_description}' result: {status}. Message: {message}")
         return {

--- a/tests/test_agentic_executor.py
+++ b/tests/test_agentic_executor.py
@@ -108,7 +108,14 @@ class TestAgenticExecutorFlow(unittest.TestCase):
         st_stub.session_state.bot = bot
 
     def tearDown(self):
-        st_stub.session_state.__dict__.clear()
+        class SessionState(dict):
+            def __getattr__(self, item):
+                return self.get(item)
+
+            def __setattr__(self, key, value):
+                self[key] = value
+
+        st_stub.session_state = SessionState()
 
     def test_search_extract_summarize_and_log(self):
         state = {}


### PR DESCRIPTION
## Summary
- log and skip placeholder steps
- ensure tests reset Streamlit session state

## Testing
- `pytest -q` *(fails: module 'gmail_chatbot.email_main' has no attribute 'logging' and other errors)*

------
https://chatgpt.com/codex/tasks/task_b_684123ac16108326a43e20ed6c155a6e