### PR TITLE
Add Claude triage summarization

### DIFF
--- a/tests/test_triage_handler.py
+++ b/tests/test_triage_handler.py
@@ -3,18 +3,16 @@ from unittest.mock import MagicMock
 from gmail_chatbot.handlers.triage import handle_triage_query
 
 
-def test_handle_triage_with_urgent_search():
+def _setup_app(summary_return="summary", urgent_count=2):
     app = MagicMock()
     app.system_message = "sys"
     app.has_recent_assistant_phrase.return_value = False
-
-    # Action items returned
     app.memory_actions_handler.get_action_items_structured.return_value = [
         {"subject": "Finish report", "client": "Acme", "date": "2024-05-01"}
     ]
     app.memory_actions_handler.get_delegation_candidates.return_value = []
     app.memory_actions_handler.is_vector_search_available.return_value = True
-    app.memory_actions_handler.find_related_emails.return_value = [
+    urgent = [
         {
             "subject": "ASAP Meeting",
             "summary": "Need to meet ASAP",
@@ -28,9 +26,23 @@ def test_handle_triage_with_urgent_search():
             "date": "2024-05-03",
         },
     ]
+    app.memory_actions_handler.find_related_emails.return_value = urgent[
+        :urgent_count
+    ]
+    app.claude_client.summarize_triage.return_value = summary_return
+    return app
 
+
+def test_handle_triage_returns_claude_summary():
+    app = _setup_app("Great summary")
     response = handle_triage_query(app, "triage", "req", {"triage": 1.0})
+    assert response == "Great summary"
+    app.claude_client.summarize_triage.assert_called_once()
 
+
+def test_handle_triage_claude_failure_falls_back():
+    app = _setup_app("ERROR: fail")
+    response = handle_triage_query(app, "triage", "req", {"triage": 1.0})
     assert "Urgent Emails Detected" in response
     assert "ASAP Meeting" in response
     assert "Urgent: Sign" in response


### PR DESCRIPTION
## Summary
- call `summarize_triage` when there are action items or urgent results
- describe Claude-based triage summarization in docstrings
- test Claude triage call and fallback logic

## Testing
- `ruff check gmail_chatbot/handlers/triage.py tests/test_triage_handler.py`
- `black --check gmail_chatbot/handlers/triage.py tests/test_triage_handler.py`
- `pytest -q tests/test_triage_handler.py`
- `pytest -q` *(fails: AttributeError: 'SessionState' object has no attribute 'autonomous_thread_s...)*

------
https://chatgpt.com/codex/tasks/task_b_68412c50bc1083269e601609f7dcb4ba