### PR TITLE
Add test for triage summary call

### DIFF
--- a/tests/test_triage_handler.py
+++ b/tests/test_triage_handler.py
@@ -46,3 +46,19 @@ def test_handle_triage_claude_failure_falls_back():
     assert "Urgent Emails Detected" in response
     assert "ASAP Meeting" in response
     assert "Urgent: Sign" in response
+
+
+def test_handle_triage_with_claude_summary():
+    """Verify summarize_triage is invoked with action items and urgent emails."""
+    summary = "Mock triage summary"
+    app = _setup_app(summary)
+    response = handle_triage_query(app, "triage", "id123", {"triage": 0.9})
+
+    assert response == summary
+    expected_actions = app.memory_actions_handler.get_action_items_structured.return_value
+    expected_urgent = app.memory_actions_handler.find_related_emails.return_value
+    app.claude_client.summarize_triage.assert_called_once_with(
+        expected_actions,
+        expected_urgent,
+        request_id="id123",
+    )


### PR DESCRIPTION
## Summary
- expand triage handler tests with a check that `summarize_triage` is called
- verify action items and urgent results are passed when summarizing

## Testing
- `pytest tests/test_triage_handler.py -q`
- `pytest -q` *(fails: SessionState object has no attribute 'autonomous_thread_s...)*

------
https://chatgpt.com/codex/tasks/task_b_68412dbeccac8326bd0fc920b7f121c7